### PR TITLE
Debug menu stuff

### DIFF
--- a/ScriptTool/ScriptTool/Compiler.cs
+++ b/ScriptTool/ScriptTool/Compiler.cs
@@ -427,7 +427,6 @@ namespace ScriptTool
 
                             case 0x23:
                             case 0x63:
-                            case 0x98:
                             case 0xB7:
                                 sb.Append("[MONEY]");
                                 currentWidth += 36;

--- a/ScriptTool/ScriptTool/eb-codelist.json
+++ b/ScriptTool/ScriptTool/eb-codelist.json
@@ -1733,5 +1733,40 @@
     "Description": "Use compressed string $XX from bank 2",
     "Length": 2,
     "IsCompressedString": true
+  },
+  {
+    "Identifier": [
+      139
+    ],
+    "Description": "Print alpha (α) symbol",
+    "Length": 1
+  },
+  {
+    "Identifier": [
+      140
+    ],
+    "Description": "Print beta (β) symbol",
+    "Length": 1
+  },
+  {
+    "Identifier": [
+      141
+    ],
+    "Description": "Print gamma (γ) symbol",
+    "Length": 1
+  },
+  {
+    "Identifier": [
+      142
+    ],
+    "Description": "Print sigma (Σ) symbol",
+    "Length": 1
+  },
+  {
+    "Identifier": [
+      143
+    ],
+    "Description": "Print omega (Ω) symbol",
+    "Length": 1
   }
 ]

--- a/working/eb-strings.txt
+++ b/working/eb-strings.txt
@@ -5618,3 +5618,4 @@ Message of the broken SkyWalker.^L354^@(It's impossible to fix... for the time b
 [02]
 Talk to[00][00][00]Goods[00][00][00][00][00]PSI[00][00][00][00][00][00][00]Equip[00][00][00][00][00]Check[00][00][00][00][00]Status[00][00][00][00][18 05 08 00]Level:[18 05 2C 03]Hit Points:[18 05 17 04]Psychic Points:[18 05 0A 05]Experience Points:[18 05 39 06]Exp. for next level.[18 05 9C 00]Offense:[18 05 9B 01]Defense:[18 05 A4 02]Speed:[18 05 AA 03]Guts:[18 05 9F 04]Vitality:[18 05 B6 05]IQ:[18 05 AA 06]Luck:[02]
 [18 01 09][18 01 0B][02]
+^L2276^This label does not exist. This is a placeholder to keep ScriptToolGui from crashing.[02]

--- a/working/m12-strings-english.txt
+++ b/working/m12-strings-english.txt
@@ -897,7 +897,7 @@
 ^L899^@(Hot Springs.  Good all over)[1D FF][00 FF]
 ^L900^[7B FF]@Kidnapped. [1B FF 14 00][01 FF]  I was.[01 FF]  Boing![02 FF]@Kidnapper.[1B FF 14 00][01 FF]  Bad guy.[02 FF]@Bad guy[01 FF]  gone. Zoom![02 FF]@Where?[02 FF]@To the[01 FF]  past.[02 FF]@Ding, ding![1D FF][7C FF][00 FF]
 ^L901^@This is very hard for me to[01 FF]  tell you, but...[02 FF][1C FF 1D 01 _L4310_][00 FF]
-^L902^@In order to defeat Giygas,[1B FF 0F 00] who[01 FF]  is attacking from the past,[02 FF]@you must warp to the past.[02 FF]@This can be done by way of the[01 FF]  <Phase Distorter 3.>[02 FF]@However, the machine cannot[01 FF]  warp living things,[1B FF 0F 00] I mean[01 FF]  lifeforms.[02 FF]@Life is demolished in the[01 FF]  process of warping.[02 FF]@The only way to accomplish[01 FF]  the time travel is to transfer[01 FF]  your brain <program> into a[01 FF]  robot, and send the robot[01 FF]  to the past.[02 FF]@...The transfer means that your[01 FF]  spirit will go with the robot[02 FF]@while your body is left behind...[02 FF]@I cannot promise that your[01 FF]  spirit will come back after the[01 FF]  battle in the past.[02 FF]@Yet, you must understand that[01 FF]  the four of you are the chosen[01 FF]  ones.[02 FF]@Do you still wish to face Giygas[01 FF]  by traveling to the past?[22 FF][03 FF 00 00][04 FF _L4311_][05 FF _L4312_]^L4312^@Yes, it's natural to feel as[01 FF]  you do.[02 FF]@The only thing left is the[01 FF]  destruction of our planet...[1D FF][00 FF]^L4311^@...Hmmm[1B FF 14 00] ...you accept this[01 FF]  while knowing that you may not[01 FF]  be able to return to your[01 FF]  current form, right?[1B FF 1E 00][03 FF 00 00][04 FF _L4313_][05 FF _L4312_][80 FF _L4312_]^L4313^@...Yes... I see...[1B FF 14 00] You have really[01 FF]  set your mind on this...[02 FF]@Let me take a good look at[01 FF]  you now...[02 FF]@[0D FF],[1B FF 0F 00] please give me[01 FF]  that red cap...[02 FF][1B FF 3C 00][01 FF]@Ready... stand by...[02 FF][C6 FF][1B FF 01 00][86 FF _L2200_][6B FF 03 00][A0 FF D0 07 13 00 01 00][9E FF][CB FF FF 00 06 00][14 FF 6E 00][EA FF FF 00][C4 FF 00 B3][A0 FF 25 01 5F 02 01 00][9E FF][A0 FF D0 07 0A 03 01 00][9E FF][A5 FF 25 01 06 00][A0 FF 26 01 5F 02 01 00][A0 FF D0 07 0B 03 01 00][9E FF][A0 FF D0 07 0A 03 01 00][9E FF][A5 FF 26 01 06 00][A0 FF 27 01 5F 02 01 00][A0 FF D0 07 0B 03 01 00][9E FF][A0 FF D0 07 0A 03 01 00][9E FF][A5 FF 27 01 06 00][A0 FF 28 01 5F 02 01 00][A0 FF D0 07 0B 03 01 00][9E FF][A5 FF 28 01 06 00][74 FF][14 FF 6F 00][A0 FF 30 00 60 02 FF 00][EA FF FF 00][CB FF FF 00 06 00]@[0D FF]![01 FF]  [0E FF]![01 FF]  [10 FF]![02 FF]@[0F FF]!...[1B FF 14 00] my son...[02 FF]@There is no turning back now.[02 FF]@[0D FF], activate the[01 FF]  Phase Distorter 3 by your[01 FF]  own hand,[02 FF]@thereby following your own[01 FF]  destiny...[02 FF]@Will you do so?[22 FF][03 FF 00 00][04 FF _L4314_][05 FF _L4315_][80 FF _L4315_]^L4315^@...I see...[02 FF]@[0F FF]![1B FF 14 00] You do it![03 FF 00 00][04 FF _L4314_][05 FF _L4316_][80 FF _L4316_]^L4316^@Oh, you lost your nerve...[02 FF]@[0D FF]![1B FF 14 00] It is up to you...[22 FF][03 FF 00 00][04 FF _L4314_][05 FF _L4315_]^L4314^@Only a few people know of your[01 FF]  amazing courage,[02 FF]@but the number of people you[01 FF]  save through that bravery[01 FF]  is immense.[02 FF]@I feel very fortunate...[02 FF]@to be present at the beginning[01 FF]  of this monumental[01 FF]  undertaking...[02 FF][A4 FF F4 04][A4 FF F8 04][A4 FF F7 04][C4 FF 00 5B][C6 FF][08 FF 74 01][1B FF 01 00][FC FF 22 00][9E FF][14 FF 70 00][EA FF FF 00][FC FF 23 00][1B FF 3C 00][CC FF FF 00 01 00][A0 FF D0 07 5E 02 01 00][86 FF _L4040_][7E FF 01 00][09 FF 7E 01][09 FF 48 01][09 FF 4B 01][09 FF 49 01][09 FF 4A 01][09 FF 4C 01][09 FF 47 01][09 FF 51 01][09 FF 0B 00][EB FF FF 00][00 FF]^L903^@You must warp to the past[01 FF]  and fight, but...[1D FF][08 FF 1D 01][00 FF]
+^L902^@In order to defeat Giygas,[1B FF 0F 00] who[01 FF]  is attacking from the past,[02 FF]@you must warp to the past.[02 FF]@This can be done by way of the[01 FF]  <Phase Distorter 3.>[02 FF]@However, the machine cannot[01 FF]  warp living things,[1B FF 0F 00] I mean[01 FF]  lifeforms.[02 FF]@Life is demolished in the[01 FF]  process of warping.[02 FF]@The only way to accomplish[01 FF]  the time travel is[02 FF]@to transfer your brain[01 FF]  <program> into a robot,[02 FF]@and send the robot to the past.[02 FF]@...The transfer means that your[01 FF]  spirit will go with the robot[02 FF]@while your body is left behind...[02 FF]@I cannot promise that your[01 FF]  spirit will come back after the[01 FF]  battle in the past.[02 FF]@Yet, you must understand that[01 FF]  the four of you are the chosen[01 FF]  ones.[02 FF]@Do you still wish to face Giygas[01 FF]  by traveling to the past?[22 FF][03 FF 00 00][04 FF _L4311_][05 FF _L4312_]^L4312^@Yes, it's natural to feel as[01 FF]  you do.[02 FF]@The only thing left is the[01 FF]  destruction of our planet...[1D FF][00 FF]^L4311^@...Hmmm[1B FF 14 00] ...you accept this[01 FF]  while knowing[02 FF]@that you may not be able to[01 FF]  return to your current form,[02 FF]@right?[03 FF 00 00][04 FF _L4313_][05 FF _L4312_][80 FF _L4312_]^L4313^@...Yes... I see...[1B FF 14 00][01 FF]  You have really set your mind[01 FF]  on this...[02 FF]@Let me take a good look at[01 FF]  you now...[02 FF]@[0D FF],[1B FF 0F 00] please give me[01 FF]  that red cap...[02 FF][1B FF 3C 00][01 FF]@Ready... stand by...[02 FF][C6 FF][1B FF 01 00][86 FF _L2200_][6B FF 03 00][A0 FF D0 07 13 00 01 00][9E FF][CB FF FF 00 06 00][14 FF 6E 00][EA FF FF 00][C4 FF 00 B3][A0 FF 25 01 5F 02 01 00][9E FF][A0 FF D0 07 0A 03 01 00][9E FF][A5 FF 25 01 06 00][A0 FF 26 01 5F 02 01 00][A0 FF D0 07 0B 03 01 00][9E FF][A0 FF D0 07 0A 03 01 00][9E FF][A5 FF 26 01 06 00][A0 FF 27 01 5F 02 01 00][A0 FF D0 07 0B 03 01 00][9E FF][A0 FF D0 07 0A 03 01 00][9E FF][A5 FF 27 01 06 00][A0 FF 28 01 5F 02 01 00][A0 FF D0 07 0B 03 01 00][9E FF][A5 FF 28 01 06 00][74 FF][14 FF 6F 00][A0 FF 30 00 60 02 FF 00][EA FF FF 00][CB FF FF 00 06 00]@[0D FF]![01 FF]  [0E FF]![01 FF]  [10 FF]![02 FF]@[0F FF]!...[1B FF 14 00] my son...[02 FF]@There is no turning back now.[02 FF]@[0D FF], activate the Phase[01 FF]  Distorter 3 by your own[01 FF]  hand,[02 FF]@thereby following your own[01 FF]  destiny...[02 FF]@Will you do so?[03 FF 00 00][04 FF _L4314_][05 FF _L4315_][80 FF _L4315_]^L4315^@...I see...[02 FF]@[0F FF]![1B FF 14 00]  You do it![03 FF 00 00][04 FF _L4314_][05 FF _L4316_][80 FF _L4316_]^L4316^@Oh, you lost your nerve...[02 FF]@[0D FF]![1B FF 14 00]  It is up to you...[03 FF 00 00][04 FF _L4314_][05 FF _L4315_]^L4314^@Only a few people know of your[01 FF]  amazing courage,[02 FF]@but the number of people you[01 FF]  save through that bravery is[01 FF]  immense.[02 FF]@I feel very fortunate...[02 FF]@to be present at the beginning[01 FF]  of this monumental[01 FF]  undertaking...[02 FF][A4 FF F4 04][A4 FF F8 04][A4 FF F7 04][C4 FF 00 5B][C6 FF][08 FF 74 01][1B FF 01 00][FC FF 22 00][9E FF][14 FF 70 00][EA FF FF 00][FC FF 23 00][1B FF 3C 00][CC FF FF 00 01 00][A0 FF D0 07 5E 02 01 00][86 FF _L4040_][7E FF 01 00][09 FF 7E 01][09 FF 48 01][09 FF 4B 01][09 FF 49 01][09 FF 4A 01][09 FF 4C 01][09 FF 47 01][09 FF 51 01][09 FF 0B 00][EB FF FF 00][00 FF]^L903^@You must warp to the past[01 FF]  and fight, but...[1D FF][08 FF 1D 01][00 FF]
 ^L904^[7B FF]@We here too.[02 FF]@Boing![1D FF][7C FF][00 FF]
 ^L905^[1C FF DF 00 _L3265_][8D FF 01 00][A8 FF 00]@[90 FF 00][1A FF 01 00] checked the[01 FF]  broken Phase Distorter.[02 FF]@There was a Horn of life.[02 FF][91 FF FF][82 FF _L3266_][01 FF][93 FF 00 DC][86 FF _L2233_][08 FF DF 00][1D FF][00 FF]
 ^L906^@INPUT YOUR COMMAND.[1C FF 74 01 _L5141_][03 FF 0E 00]^L5143^[04 FF _L5061_][05 FF _L5142_][00 FF]^L5141^[03 FF 0F 00][80 FF _L5143_]^L5142^[86 FF _L1860_][00 FF]
@@ -3054,7 +3054,7 @@
 ^L3315^
 ^L3317^@There's an old submarine at the[01 FF]  back of the dungeon.[02 FF]@It can be used to cross the[01 FF]  river.[02 FF]@There's a <Goodbye Exit>[01 FF]  ...over there.[02 FF]@It will take you to the[01 FF]  submarine.[02 FF]@Don't make a mistake on which[01 FF]  exit you take.[02 FF]@You need to take the[01 FF]  <Goodbye Exit!>[1B FF 14 00] Hope to see you[01 FF]  again![1D FF][00 FF]
 ^L3318^@I don't know how, but my[01 FF]  homemade dungeon helped you[01 FF]  out.[02 FF]@I'm glad.[1D FF][C6 FF][00 FF]
-^L3319^[1B FF 14 00]@Guargh![1B FF 14 00] Oh no!  I... am...[02 FF]@getting caught in the palm[01 FF]  trees![1B FF 14 00] Mmm... I cannot move.[02 FF]@Well,[1B FF 14 00] if I cannot move, it is[01 FF]  okay.[02 FF][8D FF 01 00][A8 FF 00]@[90 FF 00][1A FF 01 00], it makes me[01 FF]  sad, but I must say goodbye[01 FF]  here,[1B FF 14 00] at my eternal resting[01 FF]  place.[02 FF][C6 FF][1B FF 14 00][AF FF 0A][84 FF 80 04 0C 00 01 00][08 FF 12 01][86 FF _L3558_][09 FF F4 02][D4 FF 11 00][09 FF 96 02][EB FF FF 00][1B FF 14 00][D4 FF 05 00][86 FF _L2201_][C5 FF][00 FF]
+^L3319^[1B FF 14 00]@Guargh![1B FF 14 00]  Oh no!  I... am...[02 FF]@getting caught in the palm[01 FF]  trees![1B FF 14 00]  Mmm... I cannot move.[02 FF]@Well,[1B FF 14 00] if I cannot move, it is[01 FF]  okay.[02 FF][8D FF 01 00][A8 FF 00]@[90 FF 00][1A FF 01 00], it makes me sad,[02 FF]@but I must say goodbye here,[1B FF 14 00] at[01 FF]  my eternal resting place.[02 FF][C6 FF][1B FF 14 00][AF FF 0A][84 FF 80 04 0C 00 01 00][08 FF 12 01][86 FF _L3558_][09 FF F4 02][D4 FF 11 00][09 FF 96 02][EB FF FF 00][1B FF 14 00][D4 FF 05 00][86 FF _L2201_][C5 FF][00 FF]
 ^L3320^@This path is closed.[02 FF]@...Brick Road.[1D FF][00 FF]
 ^L3321^@<Good Night Bench.>[02 FF]@May you relax and recover[01 FF]  your health and spirits.[1D FF][00 FF]
 ^L3322^@[C2 FF][1A FF 05 00]'s health is[01 FF]  restored.[1D FF][C6 FF][00 FF]
@@ -3080,7 +3080,7 @@
 ^L3346^
 ^L3347^
 ^L3348^
-^L3349^
+^L3349^@Shhhhh! Be quiet![01 FF]  I look very important, but I'm[01 FF]  not really.....[02 FF]@I'm a cash dispenser man.[02 FF]@If you want to withdraw[01 FF]  cash.....[02 FF]@I'll charge you a handling fee,[02 FF]@which is the same amount as[01 FF]  your withdrawal.[02 FF]@So, do you want a withdrawal?[86 FF _L2485_][04 FF _L5320_][05 FF _L5321_]^L5321^@...I'll be here, so...[01 FF]  Come back any time.[1D FF][00 FF]
 ^L3350^
 ^L3351^[DF FF][81 FF _L5139_]^L5139^[00 FF]
 ^L3352^
@@ -3117,7 +3117,7 @@
 ^L3385^@Hey! Strange fellow.[02 FF]@After an earthquake, the hot[01 FF]  springs erupt out of the ground.[02 FF]@Have you ever noticed that?[02 FF]@The blue springs are great for[01 FF]  recovering health.[02 FF]@The red springs are perfect for[01 FF]  healing paralysis or drawing out[01 FF]  poison.[1D FF][00 FF]
 ^L3386^@You guys helped the upper tribe[01 FF]  and the lower tribe gain unity[01 FF]  again.[02 FF]@Soon, we'll be one village again![1B FF 14 00][01 FF]  Thank you.[1D FF][00 FF]
 ^L3387^@Hot springs rock![1D FF][00 FF]
-^L3388^[1C FF 02 00 _L5335_][08 FF 02 00]@You're a foreigner, aren't you?[02 FF]@I am a world-wise Tenda.[02 FF]@I was an exchange student who[01 FF]  traveled to a country that is[01 FF]  known as an economic[01 FF]  superpower.[02 FF]@My name is Ay-go Stikke.[02 FF]@Let me know if I can do[01 FF]  anything for you.[02 FF]^L5353^[01 FF]@Shall I loan you some money?[22 FF][86 FF _L2485_][04 FF _L5336_][05 FF _L5337_]^L5337^[01 FF]@I don't feel strange about it at[01 FF]  all.[02 FF]@Please ask me any time.[1D FF][00 FF]
+^L3388^[1C FF 02 00 _L5335_][08 FF 02 00]@You're a foreigner, aren't you?[02 FF]@I am a world-wise Tenda.[02 FF]@I was an exchange student who[01 FF]  traveled to a country[02 FF]@that is known as an economic[01 FF]  superpower.[02 FF]@My name is Ay-go Stikke.[02 FF]@Let me know if I can do[01 FF]  anything for you.[02 FF]^L5353^@Shall I loan you some money?[22 FF][86 FF _L2485_][04 FF _L5336_][05 FF _L5337_]^L5337^@I don't feel strange about it at[01 FF]  all.[01 FF]  Please ask me any time.[1D FF][00 FF]
 ^L3389^@Without dinosaurs, this place[01 FF]  seems like it is missing[01 FF]   something big.[1D FF][00 FF]
 ^L3390^[08 FF DC 02][08 FF 90 02][86 FF _L4325_][09 FF DC 02][09 FF 90 02][00 FF]
 ^L3391^[8D FF 02 00][88 FF][9A FF 0B 00][81 FF _L3403_][89 FF][9A FF 0C 00][81 FF _L3403_][89 FF][9A FF 0D 00][81 FF _L3403_][89 FF][9A FF 0E 00][81 FF _L3403_][89 FF][9A FF 0F 00]^L3403^[00 FF]
@@ -3334,56 +3334,53 @@
 ^L3645^[C6 FF][1B FF 3C 00][C4 FF 00 91][1B FF 8C 00][A0 FF D1 07 62 00 01 00][1B FF 01 00][C9 FF D1 07][EB FF FF 00][A0 FF D0 07 28 02 01 00][FC FF 38 00][9E FF][CA FF][EA FF FF 00][A5 FF D1 07 06 00][FC FF 37 00][1B FF 04 00][FC FF 38 00][FC FF 2F 00][FC FF 39 00][CD FF 1B 00 04 00 B4 00][8D FF 01 00][A8 FF 00][C4 FF 00 C5]@When you defeated the[01 FF]  Starman DX, the Stonehenge[01 FF]  base ceased functioning.[02 FF][C6 FF][08 FF 46 00][08 FF 7E 00][08 FF 33 00][08 FF 37 00][08 FF FE 02][C5 FF][83 FF DB 00][82 FF _L2197_][08 FF 1A 02][00 FF]
 ^L3646^[BE FF FF 00 BB 00][81 FF _L2878_]@Gyork Gyork![02 FF]@Hey you, commoner![1B FF 14 00]  You there[01 FF]  wandering around without any[01 FF]  <Fly Honey>...[02 FF]@I am the mortal enemy of your[01 FF]  kind.[02 FF][00 FF]
 ^L3647^[2E FF][BE FF FF 00 BB 00][81 FF _L2879_]@You have defeated me...[02 FF]@Allow me to eat some Fly[01 FF]  Honey for the last time...[02 FF]@Master Belch hates people like[01 FF]  you.[02 FF]@...You see, those who don't[01 FF]  have <Fly Honey> are our mortal[01 FF]  enemies...[02 FF][C6 FF][00 FF]
-^L3648^
-^L3649^
-^L3650^
-^L3651^
-^L3652^
-^L3653^
-^L3654^
-^L3655^
-^L3656^
-^L3657^[69 FF][9C FF][8A FF][C7 FF][8B FF][95 FF 03 _L3775_ _L3776_ _L3777_][80 FF _L3661_]
-^L3658^
-^L3659^
-^L3660^
-^L3661^
-^L3662^
-^L3663^
-^L3664^[C7 FF][80 FF _L3661_]
-^L3665^
-^L3666^
+^L3648^@Option chosen: <Party Setup>[02 FF]@What to do?[01 FF]  <Add> or <Remove>?  (Yes/No)[03 FF 00 00][04 FF _L3662_][05 FF _L3663_][80 FF _L3661_]
+^L3649^@Option chosen: <Goods Setup>[02 FF]@Goods shall be configured.[01 FF]  (Valid options: 1 through 7)[01 FF]  [C8 FF 01 00][95 FF 07 _L3669_ _L3670_ _L3671_ _L3672_ _L3673_ _L3674_ _L3675_][80 FF _L3661_][00 FF]
+^L3650^@Option chosen: <Status[01 FF]  Conditions>[02 FF]@Who should receive it?[02 FF][EC FF][82 FF _L3721_][88 FF]@Which one?  (Valid options: 1[01 FF]  through 14)[01 FF][C8 FF 02 00][95 FF 0D _L3722_ _L3723_ _L3724_ _L3725_ _L3726_ _L3727_ _L3728_ _L3729_ _L3730_ _L3731_ _L3732_ _L3733_ _L3734_][80 FF _L3650_]
+^L3651^@Option chosen: <Move>[02 FF]@Where to move?  (Valid[01 FF]  options: 1 through 20)[01 FF][C8 FF 02 00][95 FF 14 _L3735_ _L3736_ _L3737_ _L3738_ _L3739_ _L3740_ _L3741_ _L3742_ _L3743_ _L3744_ _L3745_ _L3746_ _L3747_ _L3748_ _L3749_ _L3750_ _L3751_ _L3752_ _L3753_ _L3754_][80 FF _L3661_]
+^L3652^@Option chosen: <Money Setup>[02 FF]@Starting money operations.[01 FF]  (Valid options: 1 through 4)[01 FF][69 FF][9C FF][C8 FF 01 00][95 FF 04 _L3760_ _L3761_ _L3762_ _L3763_][80 FF _L3661_]
+^L3653^@Option chosen: <Level Up>[02 FF]@This section does not work[01 FF]  now.  Please return later when[01 FF]  it is implemented.[02 FF][80 FF _L3661_]@Level up whom?  All or one[01 FF]  person?  (Yes/No)[03 FF 00 00][04 FF _L3755_][05 FF _L3756_][80 FF _L3661_]
+^L3654^@Option chosen: <Unused[01 FF]  Scripts>[02 FF]@An <unused> script shall be[01 FF]  called.  This ends the debug[01 FF]  menu experience.[02 FF]@(Valid options: 1 through 5)[01 FF][69 FF][9C FF][C8 FF 01 00][BD FF 05 _L3772_ _L3773_ _L3774_ _L3349_ _L3388_][00 FF]
+^L3655^@Option chosen: <Events>[02 FF]@Enter a number.  (Valid options:[01 FF]  1 through 70)[01 FF][C8 FF 02 00][95 FF 46 _L3828_ _L3829_ _L3830_ _L3831_ _L3832_ _L3833_ _L3834_ _L3835_ _L3836_ _L3837_ _L3838_ _L3839_ _L3840_ _L3841_ _L3842_ _L3843_ _L3844_ _L3845_ _L3846_ _L3847_ _L3848_ _L3849_ _L3850_ _L3851_ _L3852_ _L3853_ _L3854_ _L3855_ _L3856_ _L3857_ _L3858_ _L3859_ _L3860_ _L3861_ _L3862_ _L3863_ _L3864_ _L3865_ _L3866_ _L3867_ _L3868_ _L3869_ _L3870_ _L3871_ _L3872_ _L3873_ _L3874_ _L3875_ _L3876_ _L3877_ _L3878_ _L3879_ _L3880_ _L3881_ _L3882_ _L3883_ _L3884_ _L3885_ _L3886_ _L3887_ _L3888_ _L3889_ _L3890_ _L3891_ _L3892_ _L3893_ _L3894_ _L3895_ _L3896_ _L3897_]@Terminated execution.[1D FF][01 FF][80 FF _L3661_]
+^L3656^@Option chosen: <Hint Shop>[02 FF]@These are the Hint Shop[01 FF]  messages.  Enter a number.[01 FF]^L3784^     [C8 FF 02 00][81 FF _L3783_]@Terminating execution.[02 FF][80 FF _L3661_]
+^L3657^@Option chosen: <Sound>[02 FF][69 FF][9C FF]@<Background Music,>[01 FF]  <Sound Effects,>[01 FF]  or <Other Effects>?[02 FF]       [C8 FF 01 00][95 FF 03 _L3775_ _L3776_ _L3777_][80 FF _L3661_]
+^L3658^@Option chosen: <Descriptions>[02 FF]@Enter a Goods ID.[01 FF]   [C8 FF 03 00][82 FF _L3661_][87 FF]@This is the [90 FF 00][1A FF 02 00]'s[01 FF]  description.[02 FF][68 FF][DD FF 00 00 00 00 01 00 00 00][BD FF 01 _L1320_][DD FF 01 00 00 00 01 00 00 00][BD FF 01 _L1516_][DD FF 02 00 00 00 01 00 00 00][BD FF 01 _L1503_][DD FF 03 00 00 00 01 00 00 00][BD FF 01 _L1495_][DD FF 04 00 00 00 01 00 00 00][BD FF 01 _L1546_][DD FF 05 00 00 00 01 00 00 00][BD FF 01 _L1547_][DD FF 06 00 00 00 01 00 00 00][BD FF 01 _L1548_][DD FF 07 00 00 00 01 00 00 00][BD FF 01 _L1549_][DD FF 08 00 00 00 01 00 00 00][BD FF 01 _L1550_][DD FF 09 00 00 00 01 00 00 00][BD FF 01 _L1551_][DD FF 0A 00 00 00 01 00 00 00][BD FF 01 _L1552_][DD FF 0B 00 00 00 01 00 00 00][BD FF 01 _L1553_][DD FF 0C 00 00 00 01 00 00 00][BD FF 01 _L1554_][DD FF 0D 00 00 00 01 00 00 00][BD FF 01 _L1555_][DD FF 0E 00 00 00 01 00 00 00][BD FF 01 _L1556_][DD FF 0F 00 00 00 01 00 00 00][BD FF 01 _L1557_][DD FF 10 00 00 00 01 00 00 00][BD FF 01 _L1558_][DD FF 11 00 00 00 01 00 00 00][BD FF 01 _L1320_][DD FF 12 00 00 00 01 00 00 00][BD FF 01 _L1321_][DD FF 13 00 00 00 01 00 00 00][BD FF 01 _L1322_][DD FF 14 00 00 00 01 00 00 00][BD FF 01 _L1323_][DD FF 15 00 00 00 01 00 00 00][BD FF 01 _L1324_][DD FF 16 00 00 00 01 00 00 00][BD FF 01 _L1326_][DD FF 17 00 00 00 01 00 00 00][BD FF 01 _L1327_][DD FF 18 00 00 00 01 00 00 00][BD FF 01 _L1329_][DD FF 19 00 00 00 01 00 00 00][BD FF 01 _L1330_][DD FF 1A 00 00 00 01 00 00 00][BD FF 01 _L1331_][DD FF 1B 00 00 00 01 00 00 00][BD FF 01 _L1332_][DD FF 1C 00 00 00 01 00 00 00][BD FF 01 _L1333_][DD FF 1D 00 00 00 01 00 00 00][BD FF 01 _L1334_][DD FF 1E 00 00 00 01 00 00 00][BD FF 01 _L1335_][DD FF 1F 00 00 00 01 00 00 00][BD FF 01 _L1336_][DD FF 20 00 00 00 01 00 00 00][BD FF 01 _L1338_][DD FF 21 00 00 00 01 00 00 00][BD FF 01 _L1339_][DD FF 22 00 00 00 01 00 00 00][BD FF 01 _L1340_][DD FF 23 00 00 00 01 00 00 00][BD FF 01 _L1341_][DD FF 24 00 00 00 01 00 00 00][BD FF 01 _L1342_][DD FF 25 00 00 00 01 00 00 00][BD FF 01 _L1343_][DD FF 26 00 00 00 01 00 00 00][BD FF 01 _L1344_][DD FF 27 00 00 00 01 00 00 00][BD FF 01 _L1345_][DD FF 28 00 00 00 01 00 00 00][BD FF 01 _L1346_][DD FF 29 00 00 00 01 00 00 00][BD FF 01 _L1347_][DD FF 2A 00 00 00 01 00 00 00][BD FF 01 _L1348_][DD FF 2B 00 00 00 01 00 00 00][BD FF 01 _L1350_][DD FF 2C 00 00 00 01 00 00 00][BD FF 01 _L1351_][DD FF 2D 00 00 00 01 00 00 00][BD FF 01 _L1352_][DD FF 2E 00 00 00 01 00 00 00][BD FF 01 _L1353_][DD FF 2F 00 00 00 01 00 00 00][BD FF 01 _L1354_][DD FF 30 00 00 00 01 00 00 00][BD FF 01 _L1355_][DD FF 31 00 00 00 01 00 00 00][BD FF 01 _L1356_][DD FF 32 00 00 00 01 00 00 00][BD FF 01 _L1357_][DD FF 33 00 00 00 01 00 00 00][BD FF 01 _L1358_][DD FF 34 00 00 00 01 00 00 00][BD FF 01 _L1359_][DD FF 35 00 00 00 01 00 00 00][BD FF 01 _L1360_][DD FF 36 00 00 00 01 00 00 00][BD FF 01 _L1361_][DD FF 37 00 00 00 01 00 00 00][BD FF 01 _L1362_][DD FF 38 00 00 00 01 00 00 00][BD FF 01 _L1363_][DD FF 39 00 00 00 01 00 00 00][BD FF 01 _L1364_][DD FF 3A 00 00 00 01 00 00 00][BD FF 01 _L1365_][DD FF 3B 00 00 00 01 00 00 00][BD FF 01 _L1366_][DD FF 3C 00 00 00 01 00 00 00][BD FF 01 _L1367_][DD FF 3D 00 00 00 01 00 00 00][BD FF 01 _L1368_][DD FF 3E 00 00 00 01 00 00 00][BD FF 01 _L1370_][DD FF 3F 00 00 00 01 00 00 00][BD FF 01 _L1371_][DD FF 40 00 00 00 01 00 00 00][BD FF 01 _L1372_][DD FF 41 00 00 00 01 00 00 00][BD FF 01 _L1373_][DD FF 42 00 00 00 01 00 00 00][BD FF 01 _L1374_][DD FF 43 00 00 00 01 00 00 00][BD FF 01 _L1375_][DD FF 44 00 00 00 01 00 00 00][BD FF 01 _L1376_][DD FF 45 00 00 00 01 00 00 00][BD FF 01 _L1377_][DD FF 46 00 00 00 01 00 00 00][BD FF 01 _L1378_][DD FF 47 00 00 00 01 00 00 00][BD FF 01 _L1379_][DD FF 48 00 00 00 01 00 00 00][BD FF 01 _L1380_][DD FF 49 00 00 00 01 00 00 00][BD FF 01 _L1381_][DD FF 4A 00 00 00 01 00 00 00][BD FF 01 _L1382_][DD FF 4B 00 00 00 01 00 00 00][BD FF 01 _L1383_][DD FF 4C 00 00 00 01 00 00 00][BD FF 01 _L1384_][DD FF 4D 00 00 00 01 00 00 00][BD FF 01 _L1385_][DD FF 4E 00 00 00 01 00 00 00][BD FF 01 _L1386_][DD FF 4F 00 00 00 01 00 00 00][BD FF 01 _L1387_][DD FF 50 00 00 00 01 00 00 00][BD FF 01 _L1391_][DD FF 51 00 00 00 01 00 00 00][BD FF 01 _L1392_][DD FF 52 00 00 00 01 00 00 00][BD FF 01 _L1393_][DD FF 53 00 00 00 01 00 00 00][BD FF 01 _L1396_][DD FF 54 00 00 00 01 00 00 00][BD FF 01 _L1397_][DD FF 55 00 00 00 01 00 00 00][BD FF 01 _L1398_][DD FF 56 00 00 00 01 00 00 00][BD FF 01 _L1399_][DD FF 57 00 00 00 01 00 00 00][BD FF 01 _L1400_][DD FF 58 00 00 00 01 00 00 00][BD FF 01 _L1402_][DD FF 59 00 00 00 01 00 00 00][BD FF 01 _L1405_][DD FF 5A 00 00 00 01 00 00 00][BD FF 01 _L1412_][DD FF 5B 00 00 00 01 00 00 00][BD FF 01 _L1409_][DD FF 5C 00 00 00 01 00 00 00][BD FF 01 _L1416_][DD FF 5D 00 00 00 01 00 00 00][BD FF 01 _L1418_][DD FF 5E 00 00 00 01 00 00 00][BD FF 01 _L1422_][DD FF 5F 00 00 00 01 00 00 00][BD FF 01 _L1423_][DD FF 60 00 00 00 01 00 00 00][BD FF 01 _L1429_][DD FF 61 00 00 00 01 00 00 00][BD FF 01 _L1434_][DD FF 62 00 00 00 01 00 00 00][BD FF 01 _L1438_][DD FF 63 00 00 00 01 00 00 00][BD FF 01 _L1440_][DD FF 64 00 00 00 01 00 00 00][BD FF 01 _L1435_][DD FF 65 00 00 00 01 00 00 00][BD FF 01 _L1544_][DD FF 66 00 00 00 01 00 00 00][BD FF 01 _L1413_][DD FF 67 00 00 00 01 00 00 00][BD FF 01 _L1407_][DD FF 68 00 00 00 01 00 00 00][BD FF 01 _L1514_][DD FF 69 00 00 00 01 00 00 00][BD FF 01 _L1505_][DD FF 6A 00 00 00 01 00 00 00][BD FF 01 _L1401_][DD FF 6B 00 00 00 01 00 00 00][BD FF 01 _L1415_][DD FF 6C 00 00 00 01 00 00 00][BD FF 01 _L1419_][DD FF 6D 00 00 00 01 00 00 00][BD FF 01 _L1433_][DD FF 6E 00 00 00 01 00 00 00][BD FF 01 _L1436_][DD FF 6F 00 00 00 01 00 00 00][BD FF 01 _L1533_][DD FF 70 00 00 00 01 00 00 00][BD FF 01 _L1535_][DD FF 71 00 00 00 01 00 00 00][BD FF 01 _L1539_][DD FF 72 00 00 00 01 00 00 00][BD FF 01 _L1540_][DD FF 73 00 00 00 01 00 00 00][BD FF 01 _L1541_][DD FF 74 00 00 00 01 00 00 00][BD FF 01 _L1542_][DD FF 75 00 00 00 01 00 00 00][BD FF 01 _L1543_][DD FF 76 00 00 00 01 00 00 00][BD FF 01 _L1446_][DD FF 77 00 00 00 01 00 00 00][BD FF 01 _L1447_][DD FF 78 00 00 00 01 00 00 00][BD FF 01 _L1451_][DD FF 79 00 00 00 01 00 00 00][BD FF 01 _L1448_][DD FF 7A 00 00 00 01 00 00 00][BD FF 01 _L1445_][DD FF 7B 00 00 00 01 00 00 00][BD FF 01 _L1450_][DD FF 7C 00 00 00 01 00 00 00][BD FF 01 _L1449_][DD FF 7D 00 00 00 01 00 00 00][BD FF 01 _L1507_][DD FF 7E 00 00 00 01 00 00 00][BD FF 01 _L1452_][DD FF 7F 00 00 00 01 00 00 00][BD FF 01 _L1534_][DD FF 80 00 00 00 01 00 00 00][BD FF 01 _L1536_][DD FF 81 00 00 00 01 00 00 00][BD FF 01 _L1537_][DD FF 82 00 00 00 01 00 00 00][BD FF 01 _L1538_][DD FF 83 00 00 00 01 00 00 00][BD FF 01 _L1454_][DD FF 84 00 00 00 01 00 00 00][BD FF 01 _L1477_][DD FF 85 00 00 00 01 00 00 00][BD FF 01 _L1506_][DD FF 86 00 00 00 01 00 00 00][BD FF 01 _L1482_][DD FF 87 00 00 00 01 00 00 00][BD FF 01 _L1492_][DD FF 88 00 00 00 01 00 00 00][BD FF 01 _L1481_][DD FF 89 00 00 00 01 00 00 00][BD FF 01 _L1480_][DD FF 8A 00 00 00 01 00 00 00][BD FF 01 _L1504_][DD FF 8B 00 00 00 01 00 00 00][BD FF 01 _L1465_][DD FF 8C 00 00 00 01 00 00 00][BD FF 01 _L1530_][DD FF 8D 00 00 00 01 00 00 00][BD FF 01 _L1520_][DD FF 8E 00 00 00 01 00 00 00][BD FF 01 _L1526_][DD FF 8F 00 00 00 01 00 00 00][BD FF 01 _L1517_][DD FF 90 00 00 00 01 00 00 00][BD FF 01 _L1521_][DD FF 91 00 00 00 01 00 00 00][BD FF 01 _L1522_][DD FF 92 00 00 00 01 00 00 00][BD FF 01 _L1523_][DD FF 93 00 00 00 01 00 00 00][BD FF 01 _L1524_][DD FF 94 00 00 00 01 00 00 00][BD FF 01 _L1483_][DD FF 95 00 00 00 01 00 00 00][BD FF 01 _L1472_][DD FF 96 00 00 00 01 00 00 00][BD FF 01 _L1474_][DD FF 97 00 00 00 01 00 00 00][BD FF 01 _L1475_][DD FF 98 00 00 00 01 00 00 00][BD FF 01 _L1518_][DD FF 99 00 00 00 01 00 00 00][BD FF 01 _L1467_][DD FF 9A 00 00 00 01 00 00 00][BD FF 01 _L1508_][DD FF 9B 00 00 00 01 00 00 00][BD FF 01 _L1510_][DD FF 9C 00 00 00 01 00 00 00][BD FF 01 _L1513_][DD FF 9D 00 00 00 01 00 00 00][BD FF 01 _L1496_][DD FF 9E 00 00 00 01 00 00 00][BD FF 01 _L1564_][DD FF 9F 00 00 00 01 00 00 00][BD FF 01 _L1457_][DD FF A0 00 00 00 01 00 00 00][BD FF 01 _L1501_][DD FF A1 00 00 00 01 00 00 00][BD FF 01 _L1497_][DD FF A2 00 00 00 01 00 00 00][BD FF 01 _L1515_][DD FF A3 00 00 00 01 00 00 00][BD FF 01 _L1498_][DD FF A4 00 00 00 01 00 00 00][BD FF 01 _L1527_][DD FF A5 00 00 00 01 00 00 00][BD FF 01 _L1460_][DD FF A6 00 00 00 01 00 00 00][BD FF 01 _L1463_][DD FF A7 00 00 00 01 00 00 00][BD FF 01 _L1565_][DD FF A8 00 00 00 01 00 00 00][BD FF 01 _L1512_][DD FF A9 00 00 00 01 00 00 00][BD FF 01 _L1502_][DD FF AA 00 00 00 01 00 00 00][BD FF 01 _L1489_][DD FF AB 00 00 00 01 00 00 00][BD FF 01 _L1531_][DD FF AC 00 00 00 01 00 00 00][BD FF 01 _L1494_][DD FF AD 00 00 00 01 00 00 00][BD FF 01 _L3920_][DD FF AE 00 00 00 01 00 00 00][BD FF 01 _L1484_][DD FF AF 00 00 00 01 00 00 00][BD FF 01 _L1487_][DD FF B0 00 00 00 01 00 00 00][BD FF 01 _L1478_][DD FF B1 00 00 00 01 00 00 00][BD FF 01 _L1462_][DD FF B2 00 00 00 01 00 00 00][BD FF 01 _L1491_][DD FF B3 00 00 00 01 00 00 00][BD FF 01 _L1566_][DD FF B4 00 00 00 01 00 00 00][BD FF 01 _L1471_][DD FF B5 00 00 00 01 00 00 00][BD FF 01 _L1479_][DD FF B6 00 00 00 01 00 00 00][BD FF 01 _L1486_][DD FF B7 00 00 00 01 00 00 00][BD FF 01 _L1470_][DD FF B8 00 00 00 01 00 00 00][BD FF 01 _L1488_][DD FF B9 00 00 00 01 00 00 00][BD FF 01 _L1511_][DD FF BA 00 00 00 01 00 00 00][BD FF 01 _L1528_][DD FF BB 00 00 00 01 00 00 00][BD FF 01 _L1469_][DD FF BC 00 00 00 01 00 00 00][BD FF 01 _L1509_][DD FF BD 00 00 00 01 00 00 00][BD FF 01 _L1455_][DD FF BE 00 00 00 01 00 00 00][BD FF 01 _L1545_][DD FF BF 00 00 00 01 00 00 00][BD FF 01 _L1414_][DD FF C0 00 00 00 01 00 00 00][BD FF 01 _L1499_][DD FF C1 00 00 00 01 00 00 00][BD FF 01 _L1458_][DD FF C2 00 00 00 01 00 00 00][BD FF 01 _L1369_][DD FF C3 00 00 00 01 00 00 00][BD FF 01 _L1493_][DD FF C4 00 00 00 01 00 00 00][BD FF 01 _L1461_][DD FF C5 00 00 00 01 00 00 00][BD FF 01 _L1453_][DD FF C6 00 00 00 01 00 00 00][BD FF 01 _L1408_][DD FF C7 00 00 00 01 00 00 00][BD FF 01 _L1519_][DD FF C8 00 00 00 01 00 00 00][BD FF 01 _L1500_][DD FF C9 00 00 00 01 00 00 00][BD FF 01 _L1473_][DD FF CA 00 00 00 01 00 00 00][BD FF 01 _L1525_][DD FF CB 00 00 00 01 00 00 00][BD FF 01 _L3921_][DD FF CC 00 00 00 01 00 00 00][BD FF 01 _L1466_][DD FF CD 00 00 00 01 00 00 00][BD FF 01 _L1532_][DD FF CE 00 00 00 01 00 00 00][BD FF 01 _L1485_][DD FF CF 00 00 00 01 00 00 00][BD FF 01 _L1439_][DD FF D0 00 00 00 01 00 00 00][BD FF 01 _L1490_][DD FF D1 00 00 00 01 00 00 00][BD FF 01 _L1476_][DD FF D2 00 00 00 01 00 00 00][BD FF 01 _L1468_][DD FF D3 00 00 00 01 00 00 00][BD FF 01 _L1464_][DD FF D4 00 00 00 01 00 00 00][BD FF 01 _L1325_][DD FF D5 00 00 00 01 00 00 00][BD FF 01 _L1567_][DD FF D6 00 00 00 01 00 00 00][BD FF 01 _L1328_][DD FF D7 00 00 00 01 00 00 00][BD FF 01 _L1349_][DD FF D8 00 00 00 01 00 00 00][BD FF 01 _L1568_][DD FF D9 00 00 00 01 00 00 00][BD FF 01 _L1377_][DD FF DA 00 00 00 01 00 00 00][BD FF 01 _L1388_][DD FF DB 00 00 00 01 00 00 00][BD FF 01 _L1389_][DD FF DC 00 00 00 01 00 00 00][BD FF 01 _L1390_][DD FF DD 00 00 00 01 00 00 00][BD FF 01 _L1394_][DD FF DE 00 00 00 01 00 00 00][BD FF 01 _L1570_][DD FF DF 00 00 00 01 00 00 00][BD FF 01 _L1411_][DD FF E0 00 00 00 01 00 00 00][BD FF 01 _L1442_][DD FF E1 00 00 00 01 00 00 00][BD FF 01 _L1443_][DD FF E2 00 00 00 01 00 00 00][BD FF 01 _L1444_][DD FF E3 00 00 00 01 00 00 00][BD FF 01 _L1559_][DD FF E4 00 00 00 01 00 00 00][BD FF 01 _L1560_][DD FF E5 00 00 00 01 00 00 00][BD FF 01 _L1561_][DD FF E6 00 00 00 01 00 00 00][BD FF 01 _L1562_][DD FF E7 00 00 00 01 00 00 00][BD FF 01 _L1563_][DD FF E8 00 00 00 01 00 00 00][BD FF 01 _L1403_][DD FF E9 00 00 00 01 00 00 00][BD FF 01 _L1420_][DD FF EA 00 00 00 01 00 00 00][BD FF 01 _L1421_][DD FF EB 00 00 00 01 00 00 00][BD FF 01 _L1432_][DD FF EC 00 00 00 01 00 00 00][BD FF 01 _L1428_][DD FF ED 00 00 00 01 00 00 00][BD FF 01 _L1410_][DD FF EE 00 00 00 01 00 00 00][BD FF 01 _L1417_][DD FF EF 00 00 00 01 00 00 00][BD FF 01 _L1406_][DD FF F0 00 00 00 01 00 00 00][BD FF 01 _L1424_][DD FF F1 00 00 00 01 00 00 00][BD FF 01 _L1426_][DD FF F2 00 00 00 01 00 00 00][BD FF 01 _L1425_][DD FF F3 00 00 00 01 00 00 00][BD FF 01 _L1427_][DD FF F4 00 00 00 01 00 00 00][BD FF 01 _L1430_][DD FF F5 00 00 00 01 00 00 00][BD FF 01 _L1431_][DD FF F6 00 00 00 01 00 00 00][BD FF 01 _L1437_][DD FF F7 00 00 00 01 00 00 00][BD FF 01 _L1441_][DD FF F8 00 00 00 01 00 00 00][BD FF 01 _L1337_][DD FF F9 00 00 00 01 00 00 00][BD FF 01 _L1395_][DD FF FA 00 00 00 01 00 00 00][BD FF 01 _L1529_][DD FF FB 00 00 00 01 00 00 00][BD FF 01 _L1404_][DD FF FC 00 00 00 01 00 00 00][BD FF 01 _L1456_][DD FF FD 00 00 00 01 00 00 00][BD FF 01 _L1459_][01 FF][DD FF FE 00 00 00 01 00 00 00][82 FF _L3658_]@The maximum goods value is[01 FF]  253.[02 FF][80 FF _L3658_]
+^L3659^@Option chosen: <Teleport>[02 FF]@Testing teleportation.[01 FF]  [C8 FF 01 00][95 FF 04 _L3785_ _L3786_ _L3787_ _L3788_][80 FF _L3661_]
+^L3660^@Option chosen: <Hint Map>[02 FF]@Placing Hint Shops on the map.[02 FF][08 FF A9 02][08 FF AA 02][08 FF AB 02][08 FF AC 02][08 FF AD 02][08 FF AE 02][80 FF _L3661_]
+^L3661^@What to do?  (Valid options: 1[01 FF]  through 14)[01 FF][69 FF][9C FF][C8 FF 02 00][95 FF 0D _L3648_ _L3649_ _L3650_ _L3651_ _L3652_ _L3653_ _L3654_ _L3655_ _L3656_ _L3657_ _L3658_ _L3659_ _L3660_]@Terminated execution.[1D FF][00 FF]
+^L3662^[69 FF]@Please select a character to[01 FF]  add.  (Valid options: 1 through[01 FF]  15)[01 FF]^L3665^[C8 FF 02 00][82 FF _L3664_][87 FF][AE FF 00][69 FF][80 FF _L3665_]
+^L3663^[8D FF 02 00][82 FF _L3666_]@Please enter the position of the[01 FF]  character to be removed.[01 FF]^L3668^[8D FF 02 00][82 FF _L3667_]  [C8 FF 01 00][82 FF _L3667_][87 FF][8D FF 00 00][82 FF _L3668_][87 FF][AF FF 00]@Removing [90 FF 00][1A FF 01 00].[02 FF][80 FF _L3668_]
+^L3664^[80 FF _L3661_]
+^L3666^@There cannot be zero people.[1D FF][80 FF _L3661_]
 ^L3667^[80 FF _L3661_]
-^L3668^
-^L3669^
-^L3670^
-^L3671^
-^L3672^
-^L3673^
-^L3674^
-^L3675^
-^L3676^
-^L3677^
+^L3669^@Option chosen: <Add Goods>[02 FF]@Enter the item's ID.[01 FF]   [C8 FF 03 00][82 FF _L3676_][87 FF][91 FF FF][82 FF _L3677_][88 FF]@It is the <[90 FF 00][1A FF 02 00].>[01 FF]  Who should receive it?[86 FF _L3678_][01 FF][82 FF _L3669_][93 FF 00 00]@Added to the Goods screen.[02 FF][80 FF _L3669_]
+^L3670^@Option chosen: <Common[01 FF]  Goods> (Valid options: 1[01 FF]  through 19)[02 FF]  [C8 FF 03 00][82 FF _L3676_][87 FF]@Who should receive it?[86 FF _L3678_][82 FF _L3670_][87 FF][BD FF 13 _L3679_ _L3680_ _L3681_ _L3682_ _L3683_ _L3684_ _L3685_ _L3686_ _L3687_ _L3688_ _L3689_ _L3690_ _L3691_ _L3692_ _L3693_ _L3694_ _L3695_ _L3696_ _L3697_][80 FF _L3670_]
+^L3671^@Option chosen: <Fill Goods>[02 FF]@Filling the goods screen.[02 FF][86 FF _L3698_][80 FF _L3661_]
+^L3672^@Option chosen: <Delete Goods>[02 FF]@Starting goods deletion.  <All>[01 FF]  or <Choose>?  (Yes/No)[03 FF 00 00][04 FF _L3700_][05 FF _L3701_][80 FF _L3676_]
+^L3673^@Option chosen: <Fill Deposits>[02 FF]@Filling goods storage deposit.[BC FF 14 00]^L3709^[A8 FF 01][F4 FF 01 00 01 00][DD FF 02 00 00 00 00 00 00 00][81 FF _L3708_][77 FF 00 00][C0 FF][80 FF _L3709_]
+^L3674^@Option chosen: <Empty out[01 FF]  deposits>[02 FF]@Getting things out of goods[01 FF]  storage.^L3711^[7A FF 01 00][82 FF _L3710_][79 FF FF 00 01 00][80 FF _L3711_]
+^L3675^@Option chosen: <Strongest[01 FF]  Weapons>[02 FF]@Adding strongest weapons.[02 FF][86 FF _L3712_][80 FF _L3661_]
+^L3677^@There is no room in your[01 FF]  belongings.[02 FF]^L3676^[80 FF _L3661_]
 ^L3678^[87 FF][DE FF][87 FF][00 FF]
-^L3679^[87 FF][93 FF 00 AB][00 FF]
-^L3680^[87 FF][93 FF 00 A1][00 FF]
-^L3681^[87 FF][93 FF 00 AA][00 FF]
-^L3682^[87 FF][93 FF 00 C6][00 FF]
-^L3683^[87 FF][93 FF 00 D5][00 FF]
-^L3684^[87 FF][93 FF 00 99][00 FF]
-^L3685^[87 FF][93 FF 00 B0][00 FF]
-^L3686^[87 FF][93 FF 00 A6][00 FF]
-^L3687^[87 FF][93 FF 00 A8][00 FF]
-^L3688^[87 FF][93 FF 00 93][00 FF]
-^L3689^[87 FF][93 FF 00 C1][00 FF]
-^L3690^[87 FF][93 FF 00 A9][00 FF]
-^L3691^[87 FF][93 FF 00 C4][00 FF]
-^L3692^[87 FF][93 FF 00 D1][00 FF]
-^L3693^[87 FF][93 FF 00 8C][00 FF]
-^L3694^[87 FF][93 FF 00 98][00 FF]
-^L3695^[87 FF][93 FF 00 96][00 FF]
-^L3696^[87 FF][93 FF 00 92][00 FF]
-^L3697^[87 FF][93 FF 00 8D][00 FF]
+^L3679^@Option chosen: <Key to the[01 FF]  shack>[02 FF][87 FF][93 FF 00 AB][00 FF]
+^L3680^@Option chosen: <Receiver[01 FF]  phone>[02 FF][87 FF][93 FF 00 A1][00 FF]
+^L3681^@Option chosen: <Pencil eraser>[02 FF][87 FF][93 FF 00 AA][00 FF]
+^L3682^@Option chosen: <Franklin badge>[02 FF][87 FF][93 FF 00 C6][00 FF]
+^L3683^@Option chosen: <Key to the[01 FF]  cabin>[02 FF][87 FF][93 FF 00 D5][00 FF]
+^L3684^@Option chosen: <Wad of bills>[87 FF][93 FF 00 99][00 FF]
+^L3685^@Option chosen: <Bad key[01 FF]  machine>[02 FF][87 FF][93 FF 00 B0][00 FF]
+^L3686^@Option chosen: <Zombie paper>[02 FF][87 FF][93 FF 00 A6][00 FF]
+^L3687^@Option chosen: <Diamond>[02 FF][87 FF][93 FF 00 A8][00 FF]
+^L3688^@Option chosen: <Yogurt[01 FF]  dispenser>[02 FF][87 FF][93 FF 00 93][00 FF]
+^L3689^@Option chosen: <Hieroglyph[01 FF]  copy>[87 FF][93 FF 00 C1][00 FF]
+^L3690^@Option chosen: <Hawk eye>[02 FF][87 FF][93 FF 00 A9][00 FF]
+^L3691^@Option chosen: <Pak of bubble[01 FF]  gum>[02 FF][87 FF][93 FF 00 C4][00 FF]
+^L3692^@Option chosen: <Shyness book>[02 FF][87 FF][93 FF 00 D1][00 FF]
+^L3693^@Option chosen: <Zexonyte>[01 FF]  (Meteorite piece)[02 FF][87 FF][93 FF 00 8C][00 FF]
+^L3694^@Option chosen: <Signed banana>[02 FF][87 FF][93 FF 00 98][00 FF]
+^L3695^@Option chosen: <Eraser eraser>[02 FF][87 FF][93 FF 00 96][00 FF]
+^L3696^@Option chosen: <Tendakraut>[02 FF][87 FF][93 FF 00 92][00 FF]
+^L3697^@Option chosen: <Carrot key>[02 FF][87 FF][93 FF 00 8D][00 FF]
 ^L3698^[91 FF FF][82 FF _L3699_][93 FF 00 7D][80 FF _L3698_]
 ^L3699^[00 FF]
 ^L3700^[BC FF 01 00]^L3705^[A8 FF 01][96 FF 00][81 FF _L3702_][8D FF 00 00]^L3704^[AB FF 00 01][87 FF][82 FF _L3703_][87 FF][B9 FF 00 00 01 00][80 FF _L3704_]
@@ -3392,9 +3389,7 @@
 ^L3703^[C0 FF][80 FF _L3705_]
 ^L3706^[00 FF]
 ^L3708^[1D FF][80 FF _L3661_]
-^L3709^
 ^L3710^[1D FF][80 FF _L3661_]
-^L3711^
 ^L3712^[BC FF 01 00]^L3720^[A8 FF 01][96 FF 00][81 FF _L3713_][8D FF 00 00]^L3715^[AB FF 00 07][87 FF][82 FF _L3714_][87 FF][B9 FF 00 00 07 00][80 FF _L3715_]
 ^L3713^[00 FF]
 ^L3714^[87 FF][BD FF 04 _L3716_ _L3717_ _L3718_ _L3719_][C0 FF][80 FF _L3720_]
@@ -3403,65 +3398,59 @@
 ^L3718^[93 FF 03 24][D7 FF 00 00 00 00][93 FF 03 31][D7 FF 00 00 00 00][93 FF 03 3C][D7 FF 00 00 00 00][93 FF 03 50][D7 FF 00 00 00 00][00 FF]
 ^L3719^[93 FF 04 35][D7 FF 00 00 00 00][93 FF 04 3F][D7 FF 00 00 00 00][93 FF 04 52][D7 FF 00 00 00 00][00 FF]
 ^L3721^[80 FF _L3661_]
-^L3722^[89 FF][EE FF 00 00 01 00 01 00][EE FF 00 00 02 00 01 00][EE FF 00 00 06 00 01 00][87 FF][F7 FF 00 00 64 00][F8 FF 00 00 64 00][80 FF _L3650_]
-^L3723^[89 FF][EE FF 00 00 01 00 01 00][EE FF 00 00 01 00 02 00][87 FF][F9 FF 00 00 64 00][FA FF 00 00 64 00][80 FF _L3650_]
-^L3724^[89 FF][EE FF 00 00 01 00 01 00][EE FF 00 00 01 00 03 00][80 FF _L3650_]
-^L3725^[89 FF][EE FF 00 00 01 00 04 00][80 FF _L3650_]
-^L3726^[89 FF][EE FF 00 00 01 00 05 00][80 FF _L3650_]
-^L3727^[89 FF][EE FF 00 00 01 00 06 00][80 FF _L3650_]
-^L3728^[89 FF][EE FF 00 00 01 00 07 00][80 FF _L3650_]
-^L3729^[89 FF][EE FF 00 00 01 00 08 00][80 FF _L3650_]
-^L3730^[89 FF][EE FF 00 00 02 00 02 00][80 FF _L3650_]
-^L3731^[89 FF][EE FF 00 00 02 00 03 00][80 FF _L3650_]
-^L3732^[89 FF][EE FF 00 00 06 00 02 00][80 FF _L3650_]
-^L3733^[89 FF][87 FF][F7 FF 00 00 64 00][F9 FF 00 00 5E 00][80 FF _L3650_]
-^L3734^[89 FF][87 FF][F8 FF 00 00 64 00][FA FF 00 00 63 00][80 FF _L3650_]
-^L3735^[14 FF 19 00][00 FF]
-^L3736^[14 FF 1D 00][00 FF]
-^L3737^[14 FF B9 00][00 FF]
-^L3738^[14 FF 15 00][00 FF]
-^L3739^[14 FF 1C 00][00 FF]
-^L3740^[14 FF 1E 00][00 FF]
-^L3741^[14 FF 8F 00][00 FF]
-^L3742^[14 FF 22 00][00 FF]
-^L3743^[14 FF 90 00][00 FF]
-^L3744^[14 FF 14 00][00 FF]
-^L3745^[14 FF 18 00][00 FF]
-^L3746^[14 FF 1F 00][00 FF]
-^L3747^[14 FF 1B 00][00 FF]
-^L3748^[14 FF 20 00][00 FF]
-^L3749^[14 FF AC 00][00 FF]
-^L3750^[14 FF 16 00][00 FF]
-^L3751^[14 FF 21 00][00 FF]
-^L3752^[14 FF 17 00][00 FF]
-^L3753^[14 FF 91 00][00 FF]
-^L3754^[14 FF 1A 00][00 FF]
-^L3755^
-^L3756^
-^L3757^
-^L3758^
+^L3722^@Option chosen: <Healthy>[02 FF][89 FF][EE FF 00 00 01 00 01 00][EE FF 00 00 02 00 01 00][EE FF 00 00 06 00 01 00][87 FF][F7 FF 00 00 64 00][F8 FF 00 00 64 00][80 FF _L3650_]
+^L3723^@Option chosen: <Unconscious>[02 FF][89 FF][EE FF 00 00 01 00 01 00][EE FF 00 00 01 00 02 00][87 FF][F9 FF 00 00 64 00][FA FF 00 00 64 00][80 FF _L3650_]
+^L3724^@Option chosen: <Diamondized>[02 FF][89 FF][EE FF 00 00 01 00 01 00][EE FF 00 00 01 00 03 00][80 FF _L3650_]
+^L3725^@Option chosen: <Numb>[02 FF][89 FF][EE FF 00 00 01 00 04 00][80 FF _L3650_]
+^L3726^@Option chosen: <Nauseous>[89 FF][EE FF 00 00 01 00 05 00][80 FF _L3650_]
+^L3727^@Option chosen: <Poisoned>[02 FF][89 FF][EE FF 00 00 01 00 06 00][80 FF _L3650_]
+^L3728^@Option chosen: <Sunstroke>[02 FF][89 FF][EE FF 00 00 01 00 07 00][80 FF _L3650_]
+^L3729^@Option chosen: <Cold>[02 FF][89 FF][EE FF 00 00 01 00 08 00][80 FF _L3650_]
+^L3730^@Option chosen: <Mushroomized>[02 FF][89 FF][EE FF 00 00 02 00 02 00][80 FF _L3650_]
+^L3731^@Option chosen: <Possessed>[02 FF][89 FF][EE FF 00 00 02 00 03 00][80 FF _L3650_]
+^L3732^@Option chosen: <Homesick>[02 FF][89 FF][EE FF 00 00 06 00 02 00][80 FF _L3650_]
+^L3733^@Option chosen: <Reduced HP>[02 FF][89 FF][87 FF][F7 FF 00 00 64 00][F9 FF 00 00 5E 00][80 FF _L3650_]
+^L3734^@Option chosen: <Reduced PP>[02 FF][89 FF][87 FF][F8 FF 00 00 64 00][FA FF 00 00 63 00][80 FF _L3650_]
+^L3735^@Option chosen: <Onett>[02 FF][14 FF 19 00][00 FF]
+^L3736^@Option chosen: <Twoson>[02 FF][14 FF 1D 00][00 FF]
+^L3737^@Option chosen: <Happy Happy>[02 FF][14 FF B9 00][00 FF]
+^L3738^@Option chosen: <Peaceful Rest>[02 FF][14 FF 15 00][00 FF]
+^L3739^@Option chosen: <Threed>[02 FF][14 FF 1C 00][00 FF]
+^L3740^@Option chosen: <Winters>[02 FF][14 FF 1E 00][00 FF]
+^L3741^@Option chosen: <Saturn Valley>[02 FF][14 FF 8F 00][00 FF]
+^L3742^@Option chosen: <Secret Base>[02 FF][14 FF 22 00][00 FF]
+^L3743^@Option chosen: <Dusty Dunes[01 FF]  Desert>[02 FF][14 FF 90 00][00 FF]
+^L3744^@Option chosen: <Fourside>[02 FF][14 FF 14 00][00 FF]
+^L3745^@Option chosen: <Moonside>[02 FF][14 FF 18 00][00 FF]
+^L3746^@Option chosen: <Summers>[02 FF][14 FF 1F 00][00 FF]
+^L3747^@Option chosen: <Dalaam>[02 FF][14 FF 1B 00][00 FF]
+^L3748^@Option chosen: <Scaraba>[02 FF][14 FF 20 00][00 FF]
+^L3749^@Option chosen: <Deep Darkness>[02 FF][14 FF AC 00][00 FF]
+^L3750^@Option chosen: <Tendas>[02 FF][14 FF 16 00][00 FF]
+^L3751^@Option chosen: <Lost[01 FF]  Underworld>[02 FF][14 FF 21 00][00 FF]
+^L3752^@Option chosen: <Magicant>[02 FF][14 FF 17 00][00 FF]
+^L3753^@Option chosen: <Cave of the[01 FF]  Present>[02 FF][14 FF 91 00][00 FF]
+^L3754^@Option chosen: <Cave of the[01 FF]  Past>[02 FF][14 FF 1A 00][00 FF]
+^L3755^[86 FF _L3757_][82 FF _L3758_][87 FF]@Level would have been set.[1D FF]^L3758^[80 FF _L3661_]
+^L3756^@Please select a character.[02 FF][EC FF][82 FF _L3759_][87 FF][86 FF _L3757_][82 FF _L3759_][87 FF]  <Level up code goes here>[01 FF][80 FF _L3756_]
+^L3757^@Please enter a level.[01 FF]   [C8 FF 02 00][00 FF]
 ^L3759^[80 FF _L3661_]
-^L3760^
-^L3761^
-^L3762^
-^L3763^
+^L3760^@Option chosen: <Fill Bank>[02 FF]@Setting bank deposit to[01 FF]  $9,999,999.[1D FF][BC FF 01 00]^L3765^[A8 FF 01][87 FF][9A FF C8 00][81 FF _L3764_][D1 FF 50 C3 00 00][C0 FF][80 FF _L3765_]
+^L3761^@Option chosen: <Fill pockets>[02 FF]@Setting cash on-hand to[01 FF]  $99,999.[1D FF][BA FF 60 EA 00 00][BA FF 40 9C 00 00][9C FF][80 FF _L3661_]
+^L3762^@Option chosen: <Wallet Setup>[02 FF]@Please set an amount.[01 FF][C8 FF 05 01][82 FF _L3766_][88 FF][86 FF _L3767_][89 FF][87 FF][BA FF 00 00 00 00][9C FF]@Character's cash on hand set[01 FF]  to $[B8 FF 00][1A FF 04 00].[1D FF]^L3766^[80 FF _L3661_]
+^L3763^@Option chosen: <$0 Wallet>[02 FF][86 FF _L3767_]@Character's cash on hand set[01 FF]  to $0.[1D FF][80 FF _L3661_]
 ^L3764^[D1 FF 4F C3 00 00][80 FF _L3661_]
-^L3765^
-^L3766^
 ^L3767^[9B FF 10 27 00 00][82 FF _L3767_]^L3768^[9B FF E8 03 00 00][82 FF _L3768_]^L3769^[9B FF 64 00 00 00][82 FF _L3769_]^L3770^[9B FF 0A 00 00 00][82 FF _L3770_]^L3771^[9B FF 01 00 00 00][82 FF _L3771_][00 FF]
-^L3772^
-^L3773^
-^L3774^
-^L3775^
-^L3776^
-^L3777^
+^L3772^[86 FF _L4900_][09 FF B5 00]@I'm from Escargo Express!![02 FF]@I'm here to deliver your[02 FF][78 FF 01 00 00 00]@[90 FF 00][1A FF 02 00][78 FF 02 00 00 00][82 FF _L5229_],[01 FF]  [90 FF 00][1A FF 02 00][78 FF 03 00 00 00][82 FF _L5529_],[01 FF]  and [90 FF 00][1A FF 02 00]^L5229^.[02 FF][1C FF 49 00 _L5230_]@Your charge is $18.[01 FF]  You can pay for this, right?[22 FF][86 FF _L2492_][04 FF _L5231_][05 FF _L5232_]^L5232^@Well, I need to take these things[01 FF]  back then.[02 FF]@Is that OK?[86 FF _L2485_][04 FF _L5233_][05 FF _L5234_]^L5234^@Hmmm, what should I do?[02 FF]@You actually don't have any[01 FF]  money, right?[86 FF _L2492_][04 FF _L5231_][05 FF _L5232_][80 FF _L5232_]
+^L3773^[86 FF _L4900_][09 FF 85 02][F4 FF 01 00 01 00][DD FF 02 00 00 00 00 00 00 00][81 FF _L5207_][1C FF 49 00 _L5208_]@Hello, this is Escargo Express![02 FF]@Your delivery charge is $18.[02 FF]@You can cover the bill, right?[86 FF _L2492_][04 FF _L5209_][05 FF _L5210_]^L5210^@Oh, I see.[01 FF]  Please try us again.[1D FF][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L3774^[86 FF _L4900_][09 FF B4 00]@Hello! Mach Pizza delivery![01 FF]  Here is your pizza pie, sir.[02 FF][91 FF FF][82 FF _L5270_][A8 FF 00][88 FF][1C FF B3 00 _L5271_][BC FF 69 00]^L5274^[A8 FF 01][98 FF 00][87 FF]@That'll be $[B8 FF 00][1A FF 04 00].  You have[01 FF]  the money, don't you?[88 FF][86 FF _L2492_][04 FF _L5272_][05 FF _L5273_]^L5273^@I see.[01 FF]  Call us again.^L5276^[1D FF][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L3775^@Please select the background[01 FF]  music.[01 FF]    [C8 FF 03 00][82 FF _L3661_][87 FF][C4 FF 00 00][80 FF _L3778_]
+^L3776^@Please select the sound effect.[01 FF]^L3779^     [C8 FF 03 00][82 FF _L3661_][87 FF][D4 FF 00 00][80 FF _L3779_]
+^L3777^@Please select the <effect.>[01 FF]^L3780^     [C8 FF 02 00][82 FF _L3661_][87 FF][6B FF 00 00][80 FF _L3780_]
 ^L3778^
-^L3779^
-^L3780^
 ^L3781^
 ^L3782^
-^L3783^
-^L3784^
+^L3783^[A8 FF 00]@Displaying message number[01 FF]  [B8 FF 00][1A FF 04 00].[02 FF][01 FF][86 FF _dummiedouthintjumptablethatdidexist_][01 FF][80 FF _L3784_]^dummiedouthintjumptablethatdidexist^[95 FF 50 _L5768_ _L5769_ _L5770_ _L5771_ _L5772_ _L5773_ _L5774_ _L5775_ _L5776_ _L5777_ _L5778_ _L5779_ _L5780_ _L5781_ _L5782_ _L5783_ _L5784_ _L5785_ _L5786_ _L5787_ _L5788_ _L5789_ _L5790_ _L5791_ _L5792_ _L5793_ _L5794_ _L5795_ _L5796_ _L5797_ _L5798_ _L5799_ _L5800_ _L5801_ _L5802_ _L5803_ _L5804_ _L5805_ _L5806_ _L5807_ _L5808_ _L5809_ _L5810_ _L5811_ _L5812_ _L5813_ _L5814_ _L5815_ _L5816_ _L5817_ _L5818_ _L5819_ _L5820_ _L5821_ _L5822_ _L5823_ _L5824_ _L5825_ _L5826_ _L5827_ _L5828_ _L5829_ _L5830_ _L5831_ _L5832_ _L5833_ _L5834_ _L5835_ _L5836_ _L5837_ _L5838_ _L5839_ _L5840_ _L5841_ _L5842_ _L5843_ _L5844_ _L5845_ _L5846_ _L5847_][1D FF][00 FF]
 ^L3785^[C6 FF][EF FF 04 00 01 00][00 FF]
 ^L3786^[C6 FF][EF FF 04 00 02 00][00 FF]
 ^L3787^[C6 FF][EF FF 04 00 03 00][00 FF]
@@ -3504,81 +3493,81 @@
 ^L3824^[BC FF 3E 00][00 FF]
 ^L3825^[BC FF 3F 00][00 FF]
 ^L3826^[BC FF 40 00][00 FF]
-^L3828^
-^L3829^
-^L3830^
-^L3831^
-^L3832^
-^L3833^
-^L3834^
-^L3835^
-^L3836^
-^L3837^
-^L3838^
-^L3839^
-^L3840^
-^L3841^
-^L3842^
-^L3843^
-^L3844^
-^L3845^
-^L3846^
-^L3847^
-^L3848^
-^L3849^
-^L3850^
-^L3851^
-^L3852^
-^L3853^
-^L3854^
-^L3855^
-^L3856^
-^L3857^
-^L3858^
-^L3859^
-^L3860^
-^L3861^
-^L3862^
-^L3863^
-^L3864^
-^L3865^
-^L3866^
-^L3867^
-^L3868^
-^L3869^
-^L3870^
-^L3871^
-^L3872^
-^L3873^
-^L3874^
-^L3875^
-^L3876^
-^L3877^
-^L3878^
-^L3879^
-^L3880^
-^L3881^
-^L3882^
-^L3883^
-^L3884^
-^L3885^
-^L3886^
-^L3887^
-^L3888^
-^L3889^
-^L3890^
-^L3891^
-^L3892^
-^L3893^
-^L3894^
-^L3895^
-^L3896^
-^L3897^
+^L3828^  Event(s) here:[01 FF]  Befriending Buzz Buzz[1D FF][C6 FF][BC FF 0A 00][86 FF _L3898_][AE FF 05][AE FF 07][14 FF 73 00][00 FF]
+^L3829^  Event(s) here:[01 FF]  Buzz Buzz's Final Moments[1D FF][C6 FF][BC FF 0B 00][86 FF _L3898_][AE FF 05][AE FF 06][14 FF 74 00][00 FF]
+^L3830^  Event(s) here:[01 FF]  Defeating the Five Policemen[1D FF][C6 FF][BC FF 0D 00][86 FF _L3898_][08 FF BE 00][08 FF B6 00][08 FF C2 01][08 FF C1 01][08 FF 27 00][14 FF 75 00][00 FF]
+^L3831^  Event(s) here:[01 FF]  The Threed-Bound Bus and[01 FF]  Various Useful Things[1D FF][C6 FF][BC FF 0E 00][86 FF _L3898_][08 FF D2 00][93 FF 01 A0][93 FF 01 D1][93 FF 01 C5][93 FF 01 87][93 FF 01 CF][08 FF 00 02][14 FF 1D 00][00 FF]
+^L3832^  Event(s) here:[01 FF]  Runaway Five Performance[01 FF]  (Chaos Theater)[1D FF][C6 FF][BC FF 16 00][86 FF _L3898_][08 FF 55 00][08 FF 29 02][08 FF 25 02][08 FF 2B 00][14 FF 76 00][00 FF]
+^L3833^  Event(s) here:[01 FF]  Carpainter Brings Down[01 FF]  Lightning[1D FF][C6 FF][BC FF 14 00][86 FF _L3898_][08 FF AF 00][14 FF 77 00][00 FF]
+^L3834^  Event(s) here:[01 FF]  Paula's Rescue[1D FF][C6 FF][BC FF 15 00][86 FF _L3898_][08 FF 44 00][09 FF AF 00][93 FF 01 D5][14 FF 78 00][00 FF]
+^L3835^  Event(s) here:[01 FF]  The Runaway Five's Freedom[01 FF]  (Chaos Theater)[1D FF][C6 FF][BC FF 16 00][86 FF _L3898_][AE FF 02][93 FF 01 99][08 FF 3F 01][14 FF 79 00][00 FF]
+^L3836^  Event(s) here:[01 FF]  Caught by the Zombies[1D FF][C6 FF][BC FF 17 00][86 FF _L3898_][08 FF 29 01][AE FF 02][14 FF 7A 00][00 FF]
+^L3837^  Event(s) here:[01 FF]  The Bubble Monkey <Swims> in[01 FF]  Mid-Air[1D FF][C6 FF][BC FF 1E 00][86 FF _L3898_][AE FF 03][AF FF 01][08 FF 43 01][93 FF 03 C4][14 FF 7B 00][00 FF]
+^L3838^  Event(s) here:[01 FF]  Help from Tessie[1D FF][C6 FF][BC FF 1F 00][86 FF _L3898_][AE FF 03][AF FF 01][AE FF 09][93 FF 03 C4][08 FF 58 01][08 FF B8 02][14 FF 14 00][9D FF 01 27 _L2807_][9D FF 02 30 _L2808_][00 FF]
+^L3839^  Event(s) here:[01 FF]  Dr. Andonuts[1D FF][C6 FF][BC FF 20 00][86 FF _L3898_][AE FF 03][AF FF 01][14 FF 7D 00][00 FF]
+^L3840^  Event(s) here:[01 FF]  Venus/Runaway Five[01 FF]  Performance[1D FF][C6 FF][BC FF 28 00][86 FF _L3898_][AE FF 02][AE FF 03][14 FF 7E 00][00 FF]
+^L3841^  Event(s) here:[01 FF]  Appearance of Everyone's[01 FF]  Favorite Backhoe[1D FF][C6 FF][BC FF 28 00][86 FF _L3898_][08 FF 15 01][08 FF 16 01][08 FF 17 01][08 FF 18 01][08 FF 19 01][08 FF 48 00][09 FF 36 00][08 FF 1A 01][08 FF 10 01][AE FF 02][AE FF 03][14 FF 7F 00][00 FF]
+^L3842^  Event(s) here:[01 FF]  The Runaway Five's Concluding[01 FF]  Performance[1D FF][C6 FF][BC FF 29 00][86 FF _L3898_][09 FF 92 00][09 FF 93 00][AE FF 02][AE FF 03][93 FF 01 A8][14 FF 80 00][00 FF]
+^L3843^  Event(s) here:[01 FF]  Monotoli[1D FF][C6 FF][BC FF 2B 00][86 FF _L3898_][08 FF 8E 00][AE FF 03][14 FF 81 00][00 FF]
+^L3844^  Event(s) here:[01 FF]  The RUNAWAY Bus (Fourside)[1D FF][C6 FF][BC FF 2B 00][86 FF _L3898_][08 FF 3D 01][08 FF 8E 00][08 FF 8F 00][AE FF 03][AE FF 02][14 FF 82 00][00 FF]
+^L3845^  Event(s) here:[01 FF]  The Second Sky Runner[1D FF][C6 FF][BC FF 2C 00][86 FF _L3898_][08 FF 30 00][AE FF 03][AE FF 02][14 FF 83 00][00 FF]
+^L3846^  Event(s) here:[01 FF]  The Magic Cake in Summers[1D FF][C6 FF][BC FF 2C 00][86 FF _L3898_][08 FF CB 00][08 FF 69 02][08 FF 3D 00][AE FF 03][AE FF 02][14 FF 84 00][00 FF]
+^L3847^  Event(s) here:[01 FF]  Poo's Mu Training[1D FF][C6 FF][BC FF 32 00][86 FF _L3898_][AE FF 04][AF FF 01][9D FF 01 01 _L3899_][14 FF 85 00][00 FF]
+^L3848^  Event(s) here:[01 FF]  Second Venus Performance[1D FF][C6 FF][BC FF 32 00][86 FF _L3898_][08 FF 96 00][08 FF 11 01][08 FF 10 00][08 FF 8C 00][08 FF 34 00][86 FF _L3900_][14 FF 86 00][00 FF]
+^L3849^  Event(s) here:[01 FF]  Second Tessie[1D FF][C6 FF][BC FF 33 00][86 FF _L3898_][86 FF _L3900_][14 FF 87 00][00 FF]
+^L3850^  Event(s) here:[01 FF]  Stonehenge (Note: Being[01 FF]  Adjusted)[1D FF][C6 FF][BC FF 33 00][86 FF _L3898_][08 FF 2B 01][86 FF _L3900_][14 FF 88 00][00 FF]
+^L3851^  Event(s) here:[01 FF]  The Route Through the Sea[1D FF][C6 FF][BC FF 34 00][86 FF _L3898_][86 FF _L3900_][14 FF 89 00][00 FF]
+^L3852^  Event(s) here:[01 FF]  The Tendas and Tendakraut[1D FF][C6 FF][BC FF 3D 00][86 FF _L3898_][86 FF _L3900_][14 FF 21 00][93 FF 01 92][00 FF]
+^L3853^  Event(s) here:[01 FF]  The Pyramid Dance[1D FF][C6 FF][BC FF 34 00][86 FF _L3898_][86 FF _L3900_][14 FF 8B 00][00 FF]
+^L3854^  Event(s) here:[01 FF]  The Submarine[1D FF][C6 FF][BC FF 36 00][86 FF _L3898_][AE FF 02][AE FF 03][08 FF 12 01][14 FF 8C 00][00 FF]
+^L3855^  Event(s) here:[01 FF]  The Luminous Moss[1D FF][C6 FF][BC FF 3C 00][86 FF _L3898_][86 FF _L3900_][08 FF C4 00][14 FF 8D 00][00 FF]
+^L3856^  Event(s) here:[01 FF]  The Last of the Sounds[1D FF][C6 FF][BC FF 3D 00][86 FF _L3898_][86 FF _L3900_][08 FF C5 00][14 FF 8E 00][00 FF]
+^L3857^  Event(s) here:[01 FF]  1.5th Phase Distorter[1D FF][C6 FF][BC FF 3F 00][86 FF _L3898_][86 FF _L3900_][14 FF 8F 00][00 FF]
+^L3858^  Event(s) here:[01 FF]  Second and Third Phase[01 FF]  Distorters[1D FF][C6 FF][BC FF 3F 00][86 FF _L3898_][86 FF _L3900_][08 FF 4F 00][08 FF 86 00][08 FF 85 00][08 FF 7E 01][14 FF 8F 00][00 FF]
+^L3859^  Event(s) here:[01 FF]  Monkey Dungeon[1D FF][C6 FF][BC FF 2B 00][86 FF _L3898_][AE FF 03][93 FF 01 7C][93 FF 01 64][93 FF 01 5E][93 FF 01 5E][93 FF 01 66][93 FF 01 69][93 FF 01 69][93 FF 01 74][93 FF 01 D8][93 FF 01 65][93 FF 01 62][93 FF 01 D4][93 FF 01 AA][08 FF 3B 00][08 FF E9 02][14 FF 90 00][00 FF]
+^L3860^  Event(s) here:[01 FF]  The Old Man Apparition[01 FF]  Conquers A Second Time[1D FF][C6 FF][BC FF 2B 00][86 FF _L3898_][86 FF _L3900_][08 FF 84 00][08 FF 7E 01][9D FF 01 07 _L3901_][9D FF 02 29 _L3902_][14 FF 91 00][00 FF]
+^L3861^  Event(s) here:[01 FF]  Paula's Father[1D FF][C6 FF][BC FF 0E 00][86 FF _L3898_][08 FF D2 00][14 FF 92 00][00 FF]
+^L3862^  Event(s) here:[01 FF]  Apple Kid[1D FF][C6 FF][BC FF 0E 00][86 FF _L3898_][08 FF D2 00][93 FF 01 5A][14 FF 93 00][00 FF]
+^L3863^  Event(s) here:[01 FF]  The Real Estate's a SHAM![1D FF][C6 FF][BC FF 0C 00][86 FF _L3898_][08 FF 63 00][14 FF 94 00][00 FF]
+^L3864^  Event(s) here:[01 FF]  The Male Restroom in Onett[1D FF][C6 FF][BC FF 0C 00][86 FF _L3898_][14 FF 95 00][00 FF]
+^L3865^  Event(s) here:[01 FF]  The Old Man Apparation -[01 FF]  Pyramid[1D FF][C6 FF][BC FF 34 00][86 FF _L3898_][86 FF _L3900_][08 FF D9 00][9D FF 01 10 _L3903_][93 FF 04 A9][14 FF A6 00][00 FF]
+^L3866^  Event(s) here:[01 FF]  The Sea of Eden[1D FF][C6 FF][BC FF 3E 00][86 FF _L3898_][08 FF 24 02][14 FF A7 00][00 FF]
+^L3867^  Event(s) here:[01 FF]  Mr. Carpainter's Real Battle[1D FF][C6 FF][BC FF 15 00][86 FF _L3898_][93 FF 01 01][14 FF 77 00][00 FF]
+^L3868^  Event(s) here:[01 FF]  Everdred Breathes His Last[1D FF][C6 FF][BC FF 29 00][86 FF _L3898_][08 FF 8B 00][08 FF 3C 00][AE FF 03][93 FF 01 5A][14 FF A8 00][00 FF]
+^L3869^  Event(s) here:[01 FF]  The Maid and Gourmet Yogurt[1D FF][C6 FF][BC FF 2B 00][86 FF _L3898_][AE FF 03][93 FF 01 93][14 FF A9 00][00 FF]
+^L3870^  Event(s) here:[01 FF]  The Signed Banana Peel[1D FF][C6 FF][BC FF 32 00][86 FF _L3898_][86 FF _L3900_][93 FF 01 98][08 FF 96 00][08 FF 11 01][08 FF 10 00][08 FF 8C 00][08 FF 5B 00][14 FF AA 00][00 FF]
+^L3871^  Event(s) here:[01 FF]  The Hawk Eye in Deep Darkness[1D FF][C6 FF][BC FF 35 00][86 FF _L3898_][AE FF 02][AE FF 03][93 FF 01 A9][08 FF DA 00][14 FF AB 00][00 FF]
+^L3872^  Event(s) here:[01 FF]  Delivery of the Gourmet Yogurt[1D FF][C6 FF][BC FF 2A 00][86 FF _L3898_][08 FF 3B 00][AE FF 03][14 FF 41 00][00 FF]
+^L3873^  Event(s) here:[01 FF]  The Photographer (Frank Area)[1D FF][C6 FF][BC FF 0C 00][86 FF _L3898_][08 FF 40 00][08 FF 02 00][9D FF 02 11 _L1660_][14 FF AD 00][00 FF]
+^L3874^  Event(s) here:[01 FF]  Jeff Breakout[1D FF][C6 FF][BC FF 1E 00][86 FF _L3898_][AE FF 03][AF FF 01][AE FF 08][08 FF D4 00][08 FF 17 00][08 FF 58 00][08 FF 80 00][93 FF 03 B0][93 FF 03 18][93 FF 03 41][14 FF B8 00][00 FF]
+^L3875^  Event(s) here:[01 FF]  Dastardly Plot Delivery[1D FF][C6 FF][BC FF 33 00][86 FF _L3898_][08 FF C9 00][08 FF CA 00][86 FF _L3900_][93 FF 01 B4][14 FF 7A 00][00 FF]
+^L3876^  Event(s) here:[01 FF]  Tenda Tea[1D FF][C6 FF][BC FF 3C 00][86 FF _L3898_][86 FF _L3900_][08 FF DB 00][08 FF 9A 00][08 FF 66 00][08 FF 59 00][08 FF 9B 00][08 FF AE 01][93 FF 01 D1][14 FF 16 00][00 FF]
+^L3877^  Event(s) here:[01 FF]  Saturn Coffee[1D FF][C6 FF][BC FF 23 00][86 FF _L3898_][AE FF 02][AE FF 03][14 FF 8F 00][00 FF]
+^L3878^  Event(s) here:[01 FF]  Night Work for Jeff[1D FF][C6 FF][BC FF 3C 00][86 FF _L3898_][86 FF _L3900_][93 FF 03 E4][93 FF 03 E5][93 FF 03 E6][93 FF 03 E7][93 FF 03 B3][14 FF 8A 00][00 FF]
+^L3879^  Event(s) here:[01 FF]  Final Battle[1D FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][86 FF _L3712_][14 FF 71 00][00 FF]
+^L3880^  Event(s) here:[01 FF]  Zombie Paper[1D FF][C6 FF][BC FF 21 00][86 FF _L3898_][AE FF 02][AE FF 03][08 FF 45 00][09 FF 31 00][08 FF 57 00][93 FF 01 A6][14 FF 1C 00][00 FF]
+^L3881^  Event(s) here:[01 FF]  Boogey Tent[1D FF][C6 FF][BC FF 21 00][86 FF _L3898_][AE FF 02][AE FF 03][14 FF 1C 00][00 FF]
+^L3882^  Event(s) here:[01 FF]  Falling Down to the Lost[01 FF]  Underworld[1D FF][C6 FF][BC FF 3D 00][86 FF _L3898_][86 FF _L3900_][14 FF 29 00][00 FF]
+^L3883^  Event(s) here:[01 FF]  Teleport Monkey[1D FF][C6 FF][BC FF 2B 00][86 FF _L3898_][AE FF 03][08 FF 2A 02][08 FF 65 02][08 FF 66 02][14 FF 90 00][00 FF]
+^L3884^  Event(s) here:[01 FF]  Dungeon Man[1D FF][C6 FF][BC FF 35 00][86 FF _L3898_][AE FF 02][AE FF 03][08 FF 18 00][14 FF 55 00][9D FF 01 09 _L3319_][00 FF]
+^L3885^  Event(s) here:[01 FF]  Paula is Kidnapped[1D FF][C6 FF][BC FF 29 00][86 FF _L3898_][93 FF 02 AA][AE FF 02][AE FF 03][14 FF 50 00][9D FF 01 0B _L3904_][00 FF]
+^L3886^  Event(s) here:[01 FF]  First Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3905_][EB FF FF 00][00 FF]
+^L3887^  Event(s) here:[01 FF]  Second Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3906_][EB FF FF 00][00 FF]
+^L3888^  Event(s) here:[01 FF]  Third Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3907_][EB FF FF 00][00 FF]
+^L3889^  Event(s) here:[01 FF]  Fourth Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3908_][EB FF FF 00][00 FF]
+^L3890^  Event(s) here:[01 FF]  Fifth Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3909_][EB FF FF 00][00 FF]
+^L3891^  Event(s) here:[01 FF]  Sixth Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3910_][EB FF FF 00][00 FF]
+^L3892^  Event(s) here:[01 FF]  Seventh Ending Prayer[01 FF]  (Note: Test)[1D FF][C6 FF][BC FF 41 00][86 FF _L3898_][86 FF _L3900_][08 FF 74 01][86 FF _L3911_][EB FF FF 00][00 FF]
+^L3893^  Event(s) here:[01 FF]  Third Sky Runner[1D FF][C6 FF][BC FF 2C 00][86 FF _L3898_][AE FF 03][AE FF 02][08 FF B8 00][09 FF EC 02][14 FF 7D 00][00 FF]
+^L3894^  Event(s) here:[01 FF]  ...I'm sorry, I don't know[01 FF]  Japanese.[02 FF]@If you do, it says <mogirigakari>[01 FF]  in Japanese and <HKBTKN> in[01 FF]  EarthBound.[1D FF][C6 FF][BC FF 32 00][86 FF _L3898_][86 FF _L3900_][08 FF 96 00][08 FF 11 01][08 FF 10 00][14 FF 1F 00][00 FF]
+^L3895^  Event(s) here:[01 FF]  Starman Junior[1D FF][C6 FF][BC FF 0B 00][86 FF _L3898_][AE FF 05][AE FF 06][14 FF 73 00][9D FF 01 2B _L3912_][00 FF]
+^L3896^  Event(s) here:[01 FF]  Continued in No. 3[1D FF][C6 FF][BC FF 0B 00][86 FF _L3898_][86 FF _L2203_][00 FF]
+^L3897^  Event(s) here:[01 FF]  After Giygas was Defeated[1D FF][C6 FF][BC FF 42 00][86 FF _L3898_][AE FF 02][14 FF 72 00][00 FF]
 ^L3898^[FC FF 0F 00][86 FF _L3802_][86 FF _L3913_][08 FF 0B 00][86 FF _L3700_][93 FF 01 90][BA FF E8 03 00 00][00 FF]
 ^L3899^[08 FF 0B 00][A0 FF D0 07 FE 01 01 00][86 FF _L4040_][6B FF 02 00][1B FF 3C 00][D8 FF 04 00 03 00][1B FF 04 00][D8 FF 04 00 04 00][1B FF 04 00][D8 FF 04 00 05 00][1B FF 04 00][CB FF FF 00 06 00][A0 FF 03 00 FF 01 01 00][C4 FF 00 3C][09 FF 02 00][9E FF][1C FF 02 00 _L4166_][AA FF 03 00][A0 FF AC 00 01 02 01 00][9E FF][AA FF AC 00][86 FF _L4167_][A9 FF AC 00][9E FF][A9 FF 03 00][9E FF][1C FF 02 00 _L4166_][A0 FF 52 01 02 02 01 00][09 FF 03 00][08 FF 04 00][9E FF][1C FF 02 00 _L4168_][08 FF 03 00][9E FF][69 FF][A6 FF 52 01 03 02][09 FF 03 00][09 FF 05 00][86 FF _L4169_][1C FF 02 00 _L4168_][69 FF][86 FF _L4170_][1C FF 02 00 _L4168_][69 FF][86 FF _L4171_][1C FF 02 00 _L4168_][69 FF][86 FF _L4172_][1C FF 02 00 _L4168_][08 FF 05 00][9E FF][86 FF _L4173_][1C FF 02 00 _L4168_][08 FF 03 00][9E FF][A5 FF 52 01 06 00][FC FF 25 00][14 FF 7F 00][CC FF FF 00 01 00][D8 FF 04 00 05 00][1B FF 01 00][C5 FF][A0 FF 8C 00 01 02 01 00][9E FF][AA FF 8C 00][D8 FF 04 00 07 00][86 FF _L4174_][A9 FF 8C 00][9E FF][D8 FF 04 00 02 00][00 FF]
 ^L3900^[AE FF 02][AE FF 03][AE FF 04][00 FF]
 ^L3901^[6E FF 01 00][9D FF 01 08 _L4308_][00 FF]
-^L3902^
+^L3902^[D4 FF 63 00][A0 FF B3 00 57 02 01 00][9E FF][A5 FF B3 00 06 00][A0 FF 4E 00 0C 00 01 00][DA FF 4E 00 07 00][DA FF 4E 00 01 00][DA FF 4E 00 03 00][DA FF 4E 00 05 00][DA FF 4E 00 07 00][1B FF 01 00][DA FF 4E 00 01 00][1B FF 02 00][DA FF 4E 00 03 00][1B FF 03 00][DA FF 4E 00 05 00][1B FF 04 00][DA FF 4E 00 07 00][1B FF 05 00][DA FF 4E 00 01 00][1B FF 06 00][DA FF 4E 00 03 00][1B FF 07 00][DA FF 4E 00 05 00][1B FF 08 00][DA FF 4E 00 07 00]@Greetings![1B FF 14 00]  So, you are finally[01 FF]  here![02 FF][C6 FF][86 FF _L2866_][D4 FF 25 00][1B FF 5A 00]@Excellent![1B FF 14 00]  You are truly[01 FF]  excellent![02 FF]@There is only a little time left![1B FF 0F 00][01 FF]  I'll give you the last power.[02 FF]@I must go now...[02 FF][C6 FF][E8 FF 04 00 03 00][A5 FF 4E 00 06 00][D4 FF 63 00][A0 FF B3 00 58 02 01 00][9E FF][E8 FF 04 00 03 00]@([10 FF] became conscious[01 FF]  of PSI Starstorm [8F]!)[D4 FF 67 00][1D FF][C6 FF][00 FF]
 ^L3903^[D4 FF 63 00][A0 FF B3 00 17 02 01 00][9E FF][A5 FF B3 00 06 00][A0 FF 4E 00 0C 00 01 00][DC FF 4E 00 01 00 04 00][DA FF 4E 00 00 00][86 FF _L4214_][AF FF 04][A0 FF 03 00 18 02 01 00][9E FF][AA FF 03 00][80 FF _L4215_]
 ^L3904^[6E FF 01 00][9D FF 01 0A _L4154_][00 FF]
 ^L3905^[FC FF 1A 00][CB FF FF 00 06 00][A0 FF D2 07 00 00 FF 00][1B FF 78 00][EA FF FF 00][D4 FF 12 00][1B FF 50 00][A0 FF 28 00 82 02 01 00][9E FF][AA FF 28 00][B1 FF 28 00 CC 00][1B FF 3C 00][B4 FF 28 00][A9 FF 28 00][9E FF][AA FF 28 00][1B FF 78 00][D4 FF 09 00][1B FF 1E 00][D4 FF 61 00][1B FF 14 00][DA FF 28 00 07 00][1B FF 14 00][A0 FF 29 00 83 02 01 00][A9 FF 28 00][9E FF][1B FF 3C 00][A0 FF 2A 00 84 02 01 00][9E FF][AA FF 28 00][AA FF 29 00][AA FF 2A 00][1B FF 1E 00][86 FF _L4253_][08 FF 0A 02][FC FF 1B 00][9E FF][CC FF FF 00 01 00][09 FF 0B 00][75 FF][00 FF]
@@ -3792,11 +3781,10 @@
 ^L4149^
 ^L4150^
 ^L4153^
-^L4154^
-^L4155^
+^L4154^[BC FF 01 00][86 FF _L2177_][82 FF _L4155_][BC FF 03 00][86 FF _L2177_][81 FF _L3904_]^L4155^[BC FF 02 00][86 FF _L2177_][81 FF _L3904_][6B FF 02 00][1B FF 0A 00][74 FF][CD FF 1F 00 00 00 01 00][1B FF 14 00][CD FF 14 00 01 00 01 00][1B FF 14 00][CD FF 1F 00 00 00 01 00][1B FF 01 00][CD FF 14 00 01 00 01 00][1B FF 01 00][CD FF 1F 00 00 00 01 00][1B FF 01 00][C4 FF 00 B1][1B FF 14 00][A0 FF 1C 01 AA 01 01 00][1B FF 32 00][AF FF 02][CD FF 14 00 01 00 01 00][1B FF 14 00][CD FF 1F 00 00 00 01 00][85 FF 98 03 06 00][85 FF 99 03 06 00][85 FF A3 03 06 00][08 FF 08 03][08 FF 39 00][08 FF 2B 02][09 FF 52 02][1B FF 1E 00][1B FF 3C 00][86 FF _L4156_][D4 FF 72 00][1B FF B4 00]@Your attention please,[02 FF]@would the customer from[01 FF]  Onett,[1B FF 0F 00] Mr. [0D FF],[02 FF]@please proceed to the office on[01 FF]  the fourth floor.[02 FF]@That was customer[01 FF]  [0D FF],[1B FF 0F 00] 4th floor office...[02 FF]@Gwaaaaaaaaagh![1D FF][C6 FF][6E FF 01 00][9D FF 01 0C _L4157_][BE FF 02 00 AA 00][82 FF _L2197_][08 FF B2 02][6D FF 02 00 AA 00][00 FF]
 ^L4156^[86 FF _L2201_][C5 FF][00 FF]
-^L4157^
-^L4158^
+^L4157^[D4 FF 72 00][1B FF B4 00]@[0D FF],[1B FF 0F 00] Customer[01 FF]  [0D FF],[1B FF 0F 00] please hurry to[01 FF]  [0E FF]...[02 FF]@Gwaaaaaaargh![1D FF][C6 FF][6E FF 01 00][9D FF 01 0D _L4158_][00 FF]
+^L4158^[D4 FF 72 00][1B FF B4 00]@[0D FF],[1B FF 0F 00] Customer[01 FF]  [0D FF]...[02 FF]@Gwaagh![1B FF 14 00]  Gwaargh!![1D FF][C6 FF][6E FF 01 00][00 FF]
 ^L4159^
 ^L4160^
 ^L4162^
@@ -3804,23 +3792,18 @@
 ^L4164^
 ^L4165^
 ^L4166^[CC FF FF 00 01 00][D8 FF 04 00 02 00][A5 FF 03 00 06 00][F7 FF 04 00 64 00][61 FF 01 00][FC FF 25 00][C5 FF][00 FF]
-^L4167^
+^L4167^@Ah![1B FF 0F 00]  Prince [10 FF]...[02 FF]@I am a messenger from your[01 FF]  master...[02 FF]@He sent me to tell you that you[01 FF]  must stop your meditation[01 FF]  immediately.[02 FF]@Prince [10 FF]![02 FF]@You must come back with me[01 FF]  instead of staying in a place[01 FF]  such as this.[02 FF]@Your Master wishes it...[1B FF 0F 00] please[01 FF]  rise, Prince...[02 FF]@Your highness, you must give[01 FF]  up this trial for now... believe[01 FF]  what I say,[02 FF]@it is the truth...[1D FF][C6 FF][00 FF]
 ^L4168^[FC FF 25 00][61 FF 01 00][08 FF 03 00][1B FF 01 00][14 FF 7F 00][F7 FF 04 00 64 00][1C FF 04 00 _L4168_][09 FF 02 00][A5 FF 52 01 06 00][CC FF FF 00 01 00][D8 FF 04 00 02 00][00 FF]
-^L4169^
-^L4170^
-^L4171^
-^L4172^
-^L4173^
-^L4174^
+^L4169^@Prince [10 FF]...[02 FF]@I am the spirit of your ancient[01 FF]  lineage.[02 FF]@To complete your trial,[1B FF 0F 00] I am[01 FF]  going to break your legs.[02 FF]@You will lose the use of them.[02 FF]@Do you accept this?[03 FF 00 00][04 FF _L4176_][05 FF _L4177_]^L4177^[08 FF 02 00][C6 FF][FC FF 25 00][D4 FF 20 00][00 FF]^L4176^[86 FF _L4178_][C7 FF][00 FF]
+^L4170^@So, Prince [10 FF]...[02 FF]@you cannot walk, as your legs[01 FF]  are broken.[02 FF]@Next, I will tear your arms off...[02 FF]@I shall then take your arms and[01 FF]  feed them to the crows.[02 FF]@The taking of your arms...[02 FF]@Do you accept this?[03 FF 00 00][04 FF _L4179_][05 FF _L4177_][80 FF _L4177_]^L4179^[86 FF _L4180_][C7 FF][00 FF]
+^L4171^@Ah, Prince [10 FF]...[02 FF]@Without legs and arms, you can[01 FF]  only lie there...[02 FF]@Now, I'll cut your ears off.[02 FF]@You do not mind my taking your[01 FF]  hearing away, do you?[02 FF]@Do you accept this?[03 FF 00 00][04 FF _L4181_][05 FF _L4177_][80 FF _L4177_]^L4181^[86 FF _L4182_][C7 FF][00 FF]
+^L4172^[61 FF 03 00]@(So, Prince [10 FF].[02 FF]@No legs, no arms and no[01 FF]  sound...[02 FF]@By floating words through the[01 FF]  air,[1B FF 0F 00] I must ask you...[02 FF]@Do you care if I take your eyes?[02 FF]@Do you want to live in eternal[01 FF]  darkness?[02 FF]@I shall steal your sight...[02 FF]@Do you accept this?)[03 FF 00 00][04 FF _L4183_][05 FF _L4177_][80 FF _L4177_]^L4183^[86 FF _L4184_][C7 FF][00 FF]
+^L4173^@(So, Prince [10 FF].[02 FF]@Now, I can only communicate[01 FF]  directly with your mind.[02 FF]@Your mind is all you have left...[02 FF]@In the end, I will take your mind,[02 FF]@though you probably don't want[01 FF]  to allow that, do you?[02 FF]@So... you can't answer?[1B FF 14 00]  You[01 FF]  can't even move?[02 FF]@Are you sad, are you lonely?[02 FF]@If you lose your mind,[1B FF 0F 00][01 FF]  you also lose any feelings of[01 FF]  sadness...[02 FF]@Do you accept this?[02 FF]@I will take your mind, Prince[01 FF]  [10 FF],[1B FF 14 00] know that I will[01 FF]  possess it...)[02 FF][1B FF 14 00][C6 FF][08 FF 11 01][F7 FF 04 00 64 00][61 FF 01 00][08 FF 53 02][00 FF]
+^L4174^@Prince [10 FF]![02 FF]@You have now completed your[01 FF]  training![02 FF]@The old Master must be so[01 FF]  pleased![1B FF 14 00]  Hurry,[1B FF 0F 00] now,[1B FF 0F 00] and[01 FF]  return to the palace.[02 FF][C6 FF][00 FF]
 ^L4175^@My name is [10 FF].[1B FF 14 00][01 FF]  I am the one who will fight[01 FF]  beside you.[02 FF]@I am the servant of[01 FF]  [0D FF].[1B FF 0F 00][01 FF]  I will obey [0D FF].[02 FF]@[0D FF]! My life is in[01 FF]  your hands.[02 FF][BC FF 01 00][86 FF _L2177_][81 FF _L4186_][C6 FF][08 FF 10 00][08 FF F8 01][08 FF F3 01][00 FF]
-^L4176^
-^L4177^
 ^L4178^[C7 FF][D4 FF 3F 00][69 FF][1B FF 0A 00][F9 FF 04 00 50 00][D4 FF 3D 00][1B FF 5A 00][D4 FF 2E 00][1B FF 1E 00][00 FF]
-^L4179^
 ^L4180^[C7 FF][D4 FF 3F 00][69 FF][1B FF 0A 00][F9 FF 04 00 50 00][D4 FF 3D 00][1B FF 5A 00][D4 FF 2F 00][1B FF 1E 00][00 FF]
-^L4181^
 ^L4182^[C7 FF][69 FF][D4 FF 3F 00][1B FF 0A 00][D4 FF 3D 00][1B FF 5A 00][6B FF 02 00][74 FF][FC FF 24 00][00 FF]
-^L4183^
 ^L4184^[C6 FF][00 FF]
 ^L4185^
 ^L4186^@.....[02 FF]@I just communicated with[01 FF]  [0D FF]'s soul.[1B FF 14 00][01 FF]  Do not mind me...[02 FF][C6 FF][08 FF 10 00][08 FF F2 01][08 FF F3 01][00 FF]
@@ -3844,10 +3827,10 @@
 ^L4210^[80 FF _L1859_]
 ^L4211^[91 FF FF][82 FF _L4213_][93 FF 00 A9][86 FF _L2238_][1D FF][08 FF 5C 01][1B FF 0A 00][85 FF AB 04 06 00][00 FF]
 ^L4213^
-^L4214^
-^L4215^
-^L4216^
-^L4217^
+^L4214^@Well done.[02 FF]@You have made it![02 FF][C6 FF][86 FF _L2866_][D4 FF 25 00][1B FF 5A 00]@We finally meet, Prince[01 FF]  [10 FF].[02 FF][C6 FF][00 FF]
+^L4215^@The stars foretold that I would[01 FF]  meet you here...[02 FF]@So, now it's the time to show[01 FF]  you the way of the[01 FF]  Starstorm...[02 FF]@For a while, you must live far[01 FF]  away from your friends and live[01 FF]  with me.[02 FF]@Do you understand?[02 FF]@...There's only one answer.[02 FF]@I must stop you here even if[01 FF]  you don't want to.[02 FF]@Stay with me for a while, do[01 FF]  you understand?![02 FF][C6 FF][1B FF 1E 00][80 FF _L3302_]
+^L4216^[DA FF 03 00 01 00]@It is important that I study and[01 FF]  learn the <Starstorm>...[02 FF]@It will be most helpful to us.[02 FF]@...Once I learn it,[1B FF 0F 00] I'll meet up[01 FF]  with you, [0D FF].[02 FF]@Trust me...[1B FF 14 00]  I will see you again.[02 FF][C6 FF][08 FF 11 00][00 FF]
+^L4217^@It depends on [10 FF]'s[01 FF]  efforts.  That will determine[01 FF]  the reuniting of the group.[02 FF]@Be faithful, and wait until the[01 FF]  time comes![1D FF][C6 FF][00 FF]
 ^L4219^@A submarine?[02 FF]@I believe...[1B FF 0F 00] that I have one in my[01 FF]  old vehicle collection.[02 FF]@Please enter...[1D FF][C6 FF][1B FF 01 00]^L4218^[14 FF 55 00][86 FF _L3310_][00 FF]
 ^L4220^
 ^L4221^
@@ -3878,13 +3861,13 @@
 ^L4250^[A0 FF 05 01 00 03 01 00][80 FF _L4252_]
 ^L4251^[A0 FF 06 01 00 03 01 00][80 FF _L4252_]
 ^L4252^[9E FF][CC FF FF 00 01 00][00 FF]
-^L4253^
-^L4254^
-^L4255^
-^L4256^
-^L4257^
-^L4258^
-^L4259^
+^L4253^@(Suddenly,[01 FF]  [0D FF]'s mother[01 FF]  felt terribly uneasy,[22 FF][01 FF]@and she began to pray for the[01 FF]  safety of her son and his[01 FF]  friends.)[1B FF 96 00][C6 FF][00 FF]
+^L4254^@(Suddenly,[01 FF]  one of the Runaway Five felt[01 FF]  something stop him,[22 FF][01 FF]@and he prayed fervently for the[01 FF]  safety of [0D FF] and his[01 FF]  friends.)[1B FF 96 00][C6 FF][00 FF]
+^L4255^@([0E FF]'s father[01 FF]  thought he somehow heard[01 FF]  his daughter's voice,[22 FF][01 FF]@and prayed sincerely for the[01 FF]  safety of [0E FF] and[01 FF]  her friends.)[1B FF 96 00][C6 FF][00 FF]
+^L4256^@(Suddenly,[01 FF]  Tony felt anxious about[01 FF]  [0F FF],[22 FF][01 FF]@and he prayed strongly for the[01 FF]  safety of [0F FF] and his[01 FF]  friends.)[1B FF 96 00][C6 FF][00 FF]
+^L4257^@(A young woman in Dalaam[01 FF]  woke from a dream in which[01 FF]  Prince [10 FF] died,[22 FF][01 FF]@and she began to pray for the[01 FF]  well-being of [10 FF] and[01 FF]  his friends.)[1B FF 96 00][C6 FF][00 FF]
+^L4258^@(Suddenly,[01 FF]  Frank recalled [0D FF]'s[01 FF]  shining young face,[22 FF][01 FF]@and began to pray diligently for[01 FF]  the safety of [0D FF] and[01 FF]  his friends.)[1B FF 96 00][C6 FF][00 FF]
+^L4259^@(All of the Mr. Saturns felt a[01 FF]  new, startling feeling[22 FF][01 FF]@they had never experienced[01 FF]  before,[22 FF][01 FF]@and they all started praying for[01 FF]  the safety of [0D FF] and[01 FF]  his friends.)[1B FF 96 00][C6 FF][00 FF]
 ^L4260^[1B FF 78 00][1B FF 78 00][1B FF 78 00][1B FF 78 00][1B FF 78 00][00 FF]
 ^L4261^
 ^L4262^
@@ -3929,7 +3912,7 @@
 ^L4301^[9E FF]@You kept saying something...[02 FF][C6 FF][1B FF 1E 00][00 FF]
 ^L4302^[9E FF]@...Saturn Valley?[1B FF 1E 00][01 FF]  What's waiting for us there?[02 FF]@Anyway, we need to teleport...[02 FF][C6 FF][1B FF 1E 00][00 FF]
 ^L4308^[C4 FF 00 7F][84 FF FB 04 59 02 04 00][1B FF 78 00][1B FF 3C 00][84 FF F8 04 5A 02 01 00][84 FF F5 04 5B 02 01 00][84 FF F7 04 5C 02 01 00][9E FF][C5 FF][DB FF F5 04 01 00 FF 00][CE FF F5 04 00 00][A4 FF F8 04][A4 FF F5 04][A4 FF F7 04][86 FF _L4309_][08 FF 48 01][08 FF 49 01][08 FF 4A 01][08 FF 47 01][00 FF]
-^L4309^
+^L4309^[1C FF 1D 01 _L902_]@The Phase Distorter has been[01 FF]  completed.[02 FF]@We could finish it quickly[01 FF]  because of Mr. Saturn's[01 FF]  incredible scientific skill...[02 FF]@Giygas is attacking from our[01 FF]  exact location,[02 FF]@but he is attacking from many[01 FF]  years in the past.[02 FF][C6 FF][00 FF]
 ^L4310^[C6 FF][85 FF F5 04 06 00][84 FF F6 04 5D 02 01 00][1B FF 96 00][08 FF 4B 01][09 FF 48 01][00 FF]
 ^L4317^@hi im pokey[01 FF]  please translate[0D FF][1B FF 0F 00][1B FF 14 00][01 FF][1B FF 0A 00][02 FF][01 FF][02 FF][02 FF][01 FF][02 FF][01 FF][02 FF][01 FF][01 FF][02 FF][1B FF 0F 00][01 FF][01 FF][02 FF][1B FF 14 00][01 FF][02 FF][01 FF][02 FF][01 FF][02 FF][1B FF 14 00][01 FF][02 FF][01 FF][02 FF][01 FF][1B FF 0A 00][01 FF][02 FF][01 FF][02 FF][00 FF]
 ^L4318^[A7 FF DB 01][00 FF]
@@ -4759,39 +4742,27 @@
 ^L5204^
 ^L5205^
 ^L5206^
-^L5207^
-^L5208^
-^L5209^
-^L5210^
-^L5211^
-^L5212^
+^L5207^@Excuse me.[02 FF]@We checked your records and[01 FF]  found[02 FF]@that we are already storing too[01 FF]  many of your items.[02 FF]@We cannot accept any more[01 FF]  goods from you at this time.[02 FF]@Please contact us later when[01 FF]  we may have space for your[01 FF]  items.[1D FF][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L5208^@Hi, I'm from Escargo Express.[02 FF]@I'm here to pick up your stuff.[02 FF][80 FF _L5211_]
+^L5209^[99 FF 12 00 00 00][81 FF _L5212_]^L5211^@What do you want me to take?[02 FF]@I can take up to three things.[02 FF][69 FF]^L5225^[86 FF _L2489_][82 FF _L5210_][88 FF][F4 FF 00 00 00 00][81 FF _L5213_][89 FF][79 FF 00 00 00 00][78 FF 01 00 00 00]@[90 FF 00][1A FF 02 00]?[F4 FF 01 00 01 00][DD FF 02 00 00 00 00 00 00 00][81 FF _L5214_][01 FF]  Will there be anything else?[86 FF _L2485_][04 FF _L5215_][05 FF _L5216_][80 FF _L5216_]
+^L5212^@You don't have enough money.[02 FF]@Call us at another time.[1D FF][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
 ^L5213^[86 FF _L5226_][80 FF _L5225_]
-^L5214^
-^L5215^
-^L5216^
+^L5214^[02 FF]@We're sorry, we cannot carry[01 FF]  more than three items.[02 FF]@Please understand that it's our[01 FF]  policy.[02 FF][80 FF _L5216_]
+^L5215^@What do you want me to take?[02 FF]^L5227^[86 FF _L2489_][82 FF _L5216_][88 FF][F4 FF 00 00 00 00][81 FF _L5217_][89 FF][79 FF 00 00 00 00][78 FF 02 00 00 00]@[90 FF 00][1A FF 02 00]?[01 FF][F4 FF 01 00 01 00][DD FF 02 00 00 00 00 00 00 00][81 FF _L5214_]  Will there be anything else?[86 FF _L2485_][04 FF _L5218_][05 FF _L5216_][80 FF _L5216_]
+^L5218^@Which one do you want me to[01 FF]  take?[02 FF]^L5228^[86 FF _L2489_][82 FF _L5216_][88 FF][F4 FF 00 00 00 00][81 FF _L5219_][89 FF][79 FF 00 00 00 00][78 FF 03 00 00 00]@[90 FF 00][1A FF 02 00]?[02 FF]^L5216^@Let me just confirm your[01 FF]  request.  You want me to take[02 FF][78 FF 01 00 00 00]@the [90 FF 00][1A FF 02 00][78 FF 02 00 00 00][82 FF _L5220_][01 FF]  the [90 FF 00][1A FF 02 00][78 FF 03 00 00 00][82 FF _L5220_][01 FF]  and the [90 FF 00][1A FF 02 00].^L5220^[02 FF]@Is this correct?[86 FF _L2485_][04 FF _L5221_][05 FF _L5222_][80 FF _L5222_]
 ^L5217^[86 FF _L5226_][80 FF _L5227_]
-^L5218^
 ^L5219^[86 FF _L5226_][80 FF _L5228_]
-^L5220^
-^L5221^
-^L5222^
+^L5221^[9B FF 12 00 00 00][83 FF 49 00][BD FF 01 _L5223_][9C FF][D4 FF 76 00][86 FF _L4002_]@All right, certainly,[01 FF]  thanks a lot![1D FF][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L5222^[78 FF 01 00 01 00][93 FF 00 00][78 FF 02 00 01 00][82 FF _L5224_][93 FF 00 00][78 FF 03 00 01 00][82 FF _L5224_][93 FF 00 00]^L5224^@Well, let's start again, shall we?[02 FF][80 FF _L5225_]
 ^L5223^[BA FF 12 00 00 00][00 FF]
-^L5224^
-^L5225^
-^L5226^
-^L5227^
-^L5228^
-^L5229^
+^L5226^@I think you should keep it.[02 FF]@Do you have anything else you[01 FF]  want me to take?[02 FF][00 FF]
 ^L5231^[99 FF 12 00 00 00][81 FF _L5235_][78 FF 01 00 00 00]^L5230^[91 FF FF][82 FF _L5236_][93 FF 00 00][9B FF 12 00 00 00][78 FF 02 00 00 00][82 FF _L5237_][91 FF FF][82 FF _L5238_][93 FF 00 00][78 FF 03 00 00 00][82 FF _L5237_][91 FF FF][82 FF _L5239_][93 FF 00 00]^L5237^[86 FF _L5240_][78 FF 01 00 01 00][78 FF 02 00 01 00][78 FF 03 00 01 00][00 FF]
-^L5232^
-^L5233^
-^L5234^
-^L5235^
-^L5236^
-^L5238^
-^L5239^
-^L5240^
-^L5241^
+^L5233^@Okay.[01 FF]  Call us again later.[1D FF][86 FF _L4002_][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L5235^@Ah, I see...  You don't have[01 FF]  enough money.  Call us again[01 FF]  later.[1D FF][86 FF _L4002_][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L5236^@Oh, you have too many things.[01 FF]  Please call us again later.[1D FF][86 FF _L4002_][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
+^L5238^@I don't think you can carry[01 FF]  everything.[02 FF][78 FF 01 00 01 00]@Well, I'll leave just[01 FF]  the [90 FF 00][1A FF 02 00].[02 FF][86 FF _L5240_][78 FF 02 00 01 00][77 FF 00 00][78 FF 03 00 01 00][82 FF _L5241_][77 FF 00 00]^L5241^[00 FF]
+^L5239^@I don't think you can carry[01 FF]  everything.[02 FF][78 FF 01 00 01 00]@Well, I'll leave just[01 FF]  the [90 FF 00][1A FF 02 00][01 FF]  and[78 FF 02 00 01 00] the [90 FF 00][1A FF 02 00].[02 FF][86 FF _L5240_][78 FF 03 00 01 00][77 FF 00 00][00 FF]
+^L5240^[83 FF 49 00][BD FF 01 _L5223_][9C FF][D4 FF 76 00]@OK, here we are.[01 FF]  Thank you![1D FF][C6 FF][86 FF _L4023_][86 FF _L4910_][00 FF]
 ^L5244^[BC FF 01 00][F5 FF][82 FF _L5251_][91 FF FF][82 FF _L5252_]@What would you like[01 FF]  returned?[02 FF][69 FF]^L5254^[F1 FF][82 FF _L5248_][87 FF][88 FF][86 FF _L5048_][82 FF _L5253_][8A FF][8B FF][D4 FF 74 00][F2 FF 00 00 00 00][AB FF 00 00]@The [90 FF 00][1A FF 02 00]?[01 FF]  Take good care of it.[02 FF]@Is there anything else you want[01 FF]  returned?[03 FF 14 00][04 FF _L5244_][05 FF _L5248_][80 FF _L5248_]^L5253^[87 FF][69 FF][80 FF _L5254_]
 ^L5246^@I don't think you have anything[01 FF]  to store.[02 FF][80 FF _L5248_]
 ^L5248^@Do you need anything else from[01 FF]  me?[80 FF _L5255_]
@@ -4807,13 +4778,10 @@
 ^L5263^@You want one small pizza?[01 FF][80 FF _L5268_]
 ^L5264^@Sorry, they are all sold out.[01 FF][80 FF _L5267_]
 ^L5265^@You want one large pizza?[01 FF][08 FF B3 00]^L5268^[A8 FF 00]  We'll deliver it within 3[01 FF]  minutes.[02 FF][08 FF B4 00][CF FF 01 00][08 FF F2 02]^L5266^[D4 FF 0B 00]@(Click!)[1D FF][00 FF]
-^L5270^
+^L5270^[09 FF B3 00]@Oh, it looks like you cannot[01 FF]  carry any more.[01 FF]  Call us again some other time.[80 FF _L5276_]
 ^L5271^[09 FF B3 00][BC FF 74 00][80 FF _L5274_]
-^L5272^
-^L5273^
-^L5274^
-^L5275^
-^L5276^
+^L5272^[99 FF 00 00 00 00][81 FF _L5275_][89 FF][87 FF][91 FF FF][82 FF _L5270_][93 FF 00 00][89 FF][9B FF 00 00 00 00][9C FF][D4 FF 76 00]@Thank you very much.[80 FF _L5276_]
+^L5275^@Oh? You are a little short of[01 FF]  cash.  Well, call us again some[01 FF]  other time.[80 FF _L5276_]
 ^L5277^@What do you want to return?[02 FF][9C FF][86 FF _L2489_][82 FF _L5278_][88 FF][AB FF 00 00][B7 FF 00][82 FF _L5279_]@The [90 FF 00][1A FF 02 00]?[01 FF]  We can give you[01 FF]  back [87 FF]$[B8 FF 00][1A FF 04 00].[02 FF]@Would you like to do that?[86 FF _L2485_][04 FF _L5280_][05 FF _L5281_]^L5281^[80 FF _L5282_]
 ^L5279^@We're very sorry, but we don't[01 FF]  deal with that product.[02 FF][80 FF _L5282_]
 ^L5280^[BA FF 00 00 00 00][9C FF][D4 FF 76 00][89 FF][B9 FF 00 00 00 00]@Thank you very much.[02 FF]^L5282^@Do you have anything else?[86 FF _L2485_][04 FF _L5277_][05 FF _L5283_][80 FF _L3035_]
@@ -4853,35 +4821,32 @@
 ^L5317^[BC FF 70 00][08 FF AB 01][00 FF]
 ^L5318^[BC FF 58 00][08 FF AA 01][00 FF]
 ^L5319^[BC FF 6C 00][08 FF A9 01][00 FF]
-^L5320^
-^L5321^
-^L5322^
-^L5323^
-^L5324^
-^L5325^
-^L5326^
-^L5327^
-^L5328^
-^L5329^
-^L5330^
-^L5331^
-^L5332^
-^L5333^
-^L5334^
-^L5335^@Hi! I'm Ay-go.[02 FF][80 FF _L5353_]
-^L5336^@If you want to withdraw.....[02 FF]@I will charge you a handling fee[01 FF]  that is equal to the amount of[01 FF]  your withdrawal.[02 FF]@Is that okay with you?[86 FF _L2485_][04 FF _L5338_][05 FF _L5339_]^L5339^[01 FF]@I don't think you've ever really[01 FF]  gotten into bad trouble.[1D FF][00 FF]
-^L5338^@You have $[23 FF] in your[01 FF]  account now.[03 FF 13 00][04 FF _L5340_][05 FF _L5341_][80 FF _L5337_]^L5341^[D0 FF 7F 96 98 00][82 FF _L5342_][86 FF _L5343_][82 FF _L5337_][87 FF][99 FF 00 00 00 00][81 FF _L5344_][9B FF 00 00 00 00][D1 FF 00 00 00 00][9C FF][D4 FF 76 00][1B FF 0A 00][01 FF]@I have registered your deposit[01 FF]  of $[B8 FF 00][1A FF 04 00].[02 FF][80 FF _L5345_]
-^L5340^[D0 FF 01 00 00 00][81 FF _L5346_][99 FF 9F 86 01 00][82 FF _L5347_][86 FF _L5348_][82 FF _L5337_][87 FF][D0 FF 00 00 00 00][81 FF _L5349_][D3 FF 00 00][D0 FF 00 00 00 00][81 FF _L5350_]@Your withdrawal is[01 FF]  $[B8 FF 00][1A FF 04 00],[02 FF]@and the handling fee is[01 FF]  $[B8 FF 00][1A FF 04 00].[02 FF]@Is it okay if I subtract this[01 FF]  amount from your account?[86 FF _L2485_][04 FF _L5351_][05 FF _L5352_]^L5352^[D1 FF 00 00 00 00][80 FF _L5339_]
+^L5320^@You have $[23 FF] in your[01 FF]  account now.[03 FF 13 00][04 FF _L5322_][05 FF _L5323_][80 FF _L5321_]^L5323^[D0 FF 7F 96 98 00][82 FF _L5234_][86 FF _L5325_][82 FF _L5321_][87 FF][99 FF 00 00 00 00][81 FF _L5326_][9B FF 00 00 00 00][D1 FF 00 00 00 00][9C FF][D4 FF 76 00][1B FF 0A 00]@I have registered your deposit[01 FF]  of $[B8 FF 00][1A FF 04 00].[02 FF][80 FF _L5327_]
+^L5322^[D0 FF 01 00 00 00][81 FF _L5328_][99 FF 9F 86 01 00][82 FF _L5329_][86 FF _L5330_][82 FF _L5321_][87 FF][D0 FF 00 00 00 00][81 FF _L5331_][D3 FF 00 00][D0 FF 00 00 00 00][81 FF _L5332_]@Your cash withdrawal[01 FF]  is $[B8 FF 00][1A FF 04 00],[02 FF]@and the handling charge[01 FF]  is $[B8 FF 00][1A FF 04 00].[02 FF]@I will subtract this amount from[01 FF]  your account.[02 FF]@Is that okay with you?[86 FF _L2485_][04 FF _L5333_][05 FF _L5334_]^L5334^[D1 FF 00 00 00 00][80 FF _L5321_]
+^L5324^@I don't think you can deposit[01 FF]  any more money.[02 FF][80 FF _L5321_]
+^L5325^@How much will you deposit?[02 FF]@Balance: $[23 FF][01 FF][86 FF _L5138_][00 FF]
+^L5326^@I don't think you have that[01 FF]  much money.[02 FF][80 FF _L5323_]
+^L5327^@Okay...[02 FF]@Please don't bother yourself[01 FF]  with me...you should continue[01 FF]  your journey.[1D FF][00 FF]
+^L5328^@I don't think you have any[01 FF]  savings in the bank.[02 FF][80 FF _L5321_]
+^L5329^@I don't think you can withdraw[01 FF]  any more money.[02 FF][80 FF _L5321_]
+^L5330^@How much do you want to[01 FF]  withdraw?[02 FF]@Balance: $[23 FF][01 FF][86 FF _L5138_][00 FF]
+^L5331^@I don't think you have that[01 FF]  much money in your account.[02 FF][80 FF _L5322_]
+^L5332^[D1 FF 00 00 00 00]@I don't think you have enough[01 FF]  money for my handling fee.[02 FF][80 FF _L5322_]
+^L5333^[D3 FF 00 00][BA FF 00 00 00 00][9C FF][D4 FF 74 00][1B FF 0A 00]@Your withdrawal[01 FF]  is $[B8 FF 00][1A FF 04 00].[02 FF][80 FF _L5327_]
+^L5335^@Hi!  I'm Ay-go.[02 FF][80 FF _L5353_]
+^L5336^@If you want to withdraw.....[02 FF]@I will charge you a handling fee[02 FF]@that is equal to the amount of[01 FF]  your withdrawal.[02 FF]@Is that okay with you?[86 FF _L2485_][04 FF _L5338_][05 FF _L5339_]^L5339^@I don't think you've ever really[01 FF]  gotten into bad trouble.[1D FF][00 FF]
+^L5338^@You have $[23 FF] in your[01 FF]  account now.[03 FF 13 00][04 FF _L5340_][05 FF _L5341_][80 FF _L5337_]^L5341^[D0 FF 7F 96 98 00][82 FF _L5342_][86 FF _L5343_][82 FF _L5337_][87 FF][99 FF 00 00 00 00][81 FF _L5344_][9B FF 00 00 00 00][D1 FF 00 00 00 00][9C FF][D4 FF 76 00][1B FF 0A 00]@I have registered your deposit[01 FF]  of $[B8 FF 00][1A FF 04 00].[02 FF][80 FF _L5345_]
+^L5340^[D0 FF 01 00 00 00][81 FF _L5346_][99 FF 9F 86 01 00][82 FF _L5347_][86 FF _L5348_][82 FF _L5337_][87 FF][D0 FF 00 00 00 00][81 FF _L5349_][D3 FF 00 00][D0 FF 00 00 00 00][81 FF _L5350_]@Your withdrawal[01 FF]  is $[B8 FF 00][1A FF 04 00],[02 FF]@and the handling fee[01 FF]  is $[B8 FF 00][1A FF 04 00].[02 FF]@Is it okay if I subtract this[01 FF]  amount from your account?[86 FF _L2485_][04 FF _L5351_][05 FF _L5352_]^L5352^[D1 FF 00 00 00 00][80 FF _L5339_]
 ^L5342^@I don't think you can deposit[01 FF]  any more money.[02 FF][80 FF _L5337_]
-^L5343^@How much do you want to[01 FF]  withdraw?[01 FF][86 FF _L5138_][00 FF]
+^L5343^@How much do you want to[01 FF]  deposit?[02 FF]  (account:$[23 FF])[01 FF][86 FF _L5138_][00 FF]
 ^L5344^@I don't think you have that[01 FF]  much money.[02 FF][80 FF _L5341_]
 ^L5345^@It was a very good opportunity[01 FF]  for the both of us.[02 FF]@Please come again.[1D FF][00 FF]
-^L5346^
-^L5347^
-^L5348^
-^L5349^
-^L5350^
-^L5351^
+^L5346^@You don't have any money in[01 FF]  your account.[02 FF][80 FF _L5337_]
+^L5347^@I think it's impossible for you to[01 FF]  carry any more money.[02 FF][80 FF _L5337_]
+^L5348^@How much do you want to[01 FF]  withdraw?[02 FF]  (account:$[23 FF])[01 FF][86 FF _L5138_][00 FF]
+^L5349^@You don't have that much[01 FF]  money in your account.[02 FF][80 FF _L5340_]
+^L5350^[D1 FF 00 00 00 00]@I don't think you can cover my[01 FF]  handling charge.[02 FF][80 FF _L5340_]
+^L5351^[D3 FF 00 00][BA FF 00 00 00 00][9C FF][D4 FF 74 00][1B FF 0A 00]@Your withdrawal[01 FF]  is $[B8 FF 00][1A FF 04 00].[02 FF][80 FF _L5345_]
 ^L5361^@I can only treat an illness.[01 FF]  Sorry.[86 FF _L5367_]^L5356^[92 FF 01 06 02][82 FF _L5369_][02 FF]@[1B FF 0F 00]...[1B FF 0F 00]by the way,[02 FF]@What a sad look in your eyes... [01 FF]  you, the boy in a red cap.[02 FF]@You must be homesick.[02 FF]@That's nothing you need to be[01 FF]  ashamed of.[02 FF]@Anybody who is on a long trip[01 FF]  will miss home.[02 FF]@In this case,[02 FF]@the best thing to do is to call[01 FF]  home and hear your mom's[01 FF]  voice.[1D FF]^L5369^[00 FF]
 ^L5357^@You don't have enough money.[01 FF]  Go home, and then come again.[80 FF _L5367_]
 ^L5359^[89 FF][ED FF 00 00 02 00][95 FF 03 _L5368_ _L5361_ _L5361_]^L5368^@I don't think there is anything[01 FF]  wrong with you.[80 FF _L5367_]


### PR DESCRIPTION
This PR gives a rough translation of the debug menu for use with hack debugging. It doesn't make an entrypoint, but that's easy enough to make (just add a call statement to the ATM card's item description or something).

It also edits some text that the debug menu calls, like the Cash Dispenser man and the delivery guys, and it fixes a few issues and/or crashes I ran into with ScriptTool along the way.

It might look useful, but it would probably be easier for this PR to be fixed after Stero's than for Stero's PR to be fixed after this one.

Notes:

* The text used the Japanese text where there was a difference in the stripped-down English version.
* When menus don't use a simple Yes/No, they use a number selector.
* No testing has gone into this.
* The Level-Up menu is nonfunctional since there's no level-up control code.
* No guarantees are made about this stuff actually being what the debug menu text said. I don't know Japanese, half of this was Google Translate and a pair of Japanese dictionaries.