### PR TITLE
t T Fix

### DIFF
--- a/src/m2-hack.asm
+++ b/src/m2-hack.asm
@@ -610,7 +610,12 @@ pop     {r4,pc}
 
 // "The" flag checks
 .org 0x80DB084 :: bl db04c_theflag :: nop :: nop
+.org 0x80DB110 :: bl dae9c_king_0_the
+.org 0x80DB156 :: bl db156_party_0_the
 .org 0x80DAE30 :: bl db04c_theflag :: nop :: nop
+.org 0x80DAE9C :: bl dae9c_king_0_the
+.org 0x80DAEDA :: bl daeda_party_0_the
+.org 0x80EC93C :: bl ec93c_party_0_the
 .org 0x80DCD5C :: bl dcd5c_theflag :: nop :: nop
 .org 0x80DB08E :: bl db08e_theflagflag
 .org 0x80DAE3A :: bl db08e_theflagflag

--- a/src/m2-hack.asm
+++ b/src/m2-hack.asm
@@ -611,11 +611,11 @@ pop     {r4,pc}
 // "The" flag checks
 .org 0x80DB084 :: bl db04c_theflag :: nop :: nop
 .org 0x80DB110 :: bl dae9c_king_0_the
-.org 0x80DB156 :: bl db156_party_0_the
+.org 0x80DB156 :: bl db156_party_0_the //Not needed anymore, but is a good measure
 .org 0x80DAE30 :: bl db04c_theflag :: nop :: nop
 .org 0x80DAE9C :: bl dae9c_king_0_the
-.org 0x80DAEDA :: bl daeda_party_0_the
-.org 0x80EC93C :: bl ec93c_party_0_the
+.org 0x80DAEDA :: bl daeda_party_0_the //Not needed anymore, but is a good measure
+.org 0x80EC93C :: bl ec93c_party_0_the //Leveling up - Not needed anymore, but is a good measure
 .org 0x80DCD5C :: bl dcd5c_theflag :: nop :: nop
 .org 0x80DB08E :: bl db08e_theflagflag
 .org 0x80DAE3A :: bl db08e_theflagflag
@@ -799,10 +799,10 @@ nop
 .org 0x80C9918 :: dw m2_poo_name
 .org 0x80C9928 :: dw m2_food
 .org 0x80C9938 :: dw m2_rockin
-.org 0x80C9BC0 :: dw m2_king_name
-.org 0x80DB134 :: dw m2_king_name
-.org 0x80DAEB8 :: dw m2_king_name
-.org 0x80133E8 :: dw m2_king_name
+.org 0x80C9BC0 :: dw m2_king_name //Control Code for printing its name
+.org 0x80DB134 :: dw m2_king_name //Action user related
+.org 0x80DAEB8 :: dw m2_king_name //Action target related
+.org 0x80133E8 :: dw m2_king_name //Cast Roll
 .org 0x80C2368 :: dw m2_rockin
 .org 0x80C2424 :: dw m2_rockin
 .org 0x80C24E0 :: dw m2_rockin

--- a/src/m2-vwf-entries.asm
+++ b/src/m2-vwf-entries.asm
@@ -1012,6 +1012,67 @@ pop     {pc}
 .pool
 
 //==============================================================================
+dae9c_king_0_the: //King is different than the other chosen ones, it's needed to operate on the stack before it goes to the proper address.
+push {r1,lr}
+ldmia [r0]!,r2,r3
+stmia [r1]!,r2,r3
+pop {r0}
+bl _add_0_end_of_name
+pop {pc}
+
+_get_pointer_to_stack: //r0 has the value r1 will have
+push {r1,lr}
+mov r1,r0
+ldr r0,=#0x3005220
+ldr r0,[r0,#0]
+lsl r1,r1,#4
+add r0,r0,r1
+pop {r1,pc}
+
+_add_0_end_of_name: //assumes r0 has the address to the stack.
+push {r1,lr}
+@@cycle:
+ldrb r1,[r0,#0]
+cmp r1,#0
+beq @@end_of_cycle
+@@keep_going:
+add r0,#1
+b @@cycle
+@@end_of_cycle:
+ldrb r1,[r0,#1]
+cmp r1,#0xFF
+bne @@keep_going
+mov r1,#0
+strb r1,[r0,#2]
+pop {r1,pc}
+//==============================================================================
+daeda_party_0_the:
+push {lr}
+bl 0x80DB01C
+mov r0,#0x50
+bl _get_pointer_to_stack
+bl _add_0_end_of_name
+pop {pc}
+
+//==============================================================================
+ec93c_party_0_the:
+push {lr}
+bl 0x80EC010
+mov r0,#0x50
+bl _get_pointer_to_stack
+bl _add_0_end_of_name
+pop {pc}
+
+//==============================================================================
+db156_party_0_the:
+push {lr}
+bl 0x80DB02C
+mov r0,#0x4C
+bl _get_pointer_to_stack
+bl _add_0_end_of_name
+pop {pc}
+
+//==============================================================================
 c9c58_9f_ad_minThe: //Routine that changes The to the and viceversa if need be for 9F FF and for AD FF
 push    {r2,lr}
 ldr     r0,=#0x3005220


### PR DESCRIPTION
Line of thought this is based on:
"Ok, so I thought about the t issue more.
And realized a smarter way to do it.
First I'll cover all King's instances.
Then I'll be able to use a fact we know.
The issue only happens with <= 4 letter long names that are not King's.
Because not all 7 bytes are used and you can have trash after the end.
However...
If we were to check if The or the is there after looking at the flag too...
This means that the only character names that would ever pass the check are "The " and "the ".
There is no enemy with an empty name that I'm aware of.
So if you find "The " or "the " and after that there are 00 FF, you know they are characters. If there is no The and no the, you know they're characters.
And you don't edit them.
Of course this means I'll have to cover all of King's instances because he can be 8 bytes long.
However this makes it a lot easier.
Because I actually know everywhere King is called.
No secret call code.
Of course...
This is a very specific idea.
It means no 6 letter names hack.
But it's better than having to try and see everywhere 9F FF and AD FF are used with characters."