### PR TITLE
Fix some window headers issues

### DIFF
--- a/src/m2-hack.asm
+++ b/src/m2-hack.asm
@@ -795,6 +795,17 @@ nop
 .org 0x802A75F :: db 0x30 //Add 8 extra frames before the game can start reading again.
 
 //---------------------------------------------------------
+// Fix windows printing too many tiles due to not going off of pixels, but off of characters
+//---------------------------------------------------------
+.org 0x80C0B28 :: bl c0b28_fix_char_tiles //Status window
+.org 0x80C009E :: bl c009e_fix_char_tiles //Give window
+.org 0x80C4BD6 :: bl c4bd6_fix_char_tiles //Equip window
+.org 0x80C42E0 :: bl c42e0_fix_char_tiles //Outer PSI window
+.org 0x80C3FD8 :: bl c42e0_fix_char_tiles //Inner PSI window
+.org 0x80C4448 :: bl c4448_fix_char_tiles //Inner PSI window - part 2
+.org 0x80DBF36 :: bl c009e_fix_char_tiles //Battle menu window
+
+//---------------------------------------------------------
 // Names hacks
 //---------------------------------------------------------
 //Change location of the names to allow 5-letter long characters and 6 letters long food, rockin and king
@@ -846,6 +857,8 @@ nop
 .org 0x80D6B44 :: lsl r1,r4,#3 :: sub r1,r1,r4 :: nop
 .org 0x80D6E3A :: lsl r1,r4,#3 :: sub r1,r1,r4 :: nop
 .org 0x80D6ED0 :: lsl r1,r4,#3 :: sub r1,r1,r4 :: nop
+.org 0x80C3FC6 :: lsl r1,r0,#3 :: sub r1,r1,r0 :: nop
+.org 0x80C4436 :: lsl r1,r0,#3 :: sub r1,r1,r0 :: nop
 
 //Change the way the characters' names are called. Instead of number * 6, it's now number * 7. These ones already received an lsl of 1 beforehand.
 .org 0x80C0AC8 :: lsl r1,r1,#2 :: sub r1,r1,r5
@@ -927,7 +940,13 @@ nop
 
 .org 0x80121DC :: cmp r2,#4
 .org 0x8013672 :: cmp r5,#4
-.org 0x80C0B0A :: cmp r2,#4
+.org 0x80C0B0A :: cmp r2,#4 //Status window header
+.org 0x80C4BBC :: cmp r2,#4 //Equip window header
+.org 0x80C42C6 :: cmp r2,#4 //Outer PSI window header
+.org 0x80C3FBE :: cmp r2,#4 //Inner PSI window header
+.org 0x80C442E :: cmp r2,#4 //Inner PSI window - part 2 header
+.org 0x80C0082 :: cmp r5,#4 //Give window header
+.org 0x80DBF28 :: cmp r0,#4 //Battle menu window header
 .org 0x80C97E2 :: cmp r1,#6
 .org 0x80DAF3A :: cmp r0,#6
 .org 0x80D33BC :: cmp r2,#6

--- a/src/m2-vwf-entries.asm
+++ b/src/m2-vwf-entries.asm
@@ -1380,3 +1380,74 @@ mov r2,#1
 mov r5,#0
 
 pop {pc}
+
+//==============================================================================
+//Routine for window headers that fixes the issue character - tiles
+fix_char_tiles:
+push {lr}
+lsl r0,r2,#1
+lsl r1,r2,#2
+add r1,r1,r0 //Multiply r2 (character count) by 6
+lsr r0,r1,#3 //Divide by 8
+lsl r0,r0,#3 //Re-multiply by 8
+cmp r0,r1 //Can it stay in r0 pixels? (Was this a division by 8 without remainder?)
+beq @@next
+add r0,#8 //If it cannot stay in x tiles, add 1 to the amount of tiles needed
+@@next:
+lsr r0,r0,#3 //Get the amount of tiles needed
+cmp r0,r2 //If it's not the same amout as the characters, 
+beq @@end
+sub r0,r2,r0
+lsl r0,r0,#1
+sub r6,r6,r0 //Remove the amount of extra tiles
+@@end:
+pop {pc}
+
+//==============================================================================
+//Specific fix_char_tiles routine - Status window
+c0b28_fix_char_tiles:
+push {lr}
+bl fix_char_tiles
+ldr r0,[r4,#0] //Clobbered code
+add r0,#0xB3
+pop {pc}
+
+//==============================================================================
+//Specific fix_char_tiles routine - Give window
+c009e_fix_char_tiles:
+push {lr}
+mov r2,r5
+bl fix_char_tiles
+ldr r2,=#0x30051EC //Clobbered code
+ldrh r0,[r2]
+pop {pc}
+
+//==============================================================================
+//Specific fix_char_tiles routine - Equip window
+c4bd6_fix_char_tiles:
+push {lr}
+mov r6,r7
+bl fix_char_tiles
+mov r7,r6
+ldr r2,=#0x30051EC //Clobbered code
+ldrh r0,[r2]
+pop {pc}
+
+.pool
+//==============================================================================
+//Specific fix_char_tiles routine - Outer PSI window
+c42e0_fix_char_tiles:
+push {lr}
+bl fix_char_tiles
+mov r2,r9 //Clobbered code
+ldrh r0,[r2,#0]
+pop {pc}
+
+//==============================================================================
+//Specific fix_char_tiles routine - Inner PSI window - part 2
+c4448_fix_char_tiles:
+push {lr}
+bl fix_char_tiles
+mov r2,r8 //Clobbered code
+ldrh r0,[r2,#0]
+pop {pc}

--- a/src/m2-vwf-entries.asm
+++ b/src/m2-vwf-entries.asm
@@ -1395,7 +1395,7 @@ beq @@next
 add r0,#8 //If it cannot stay in x tiles, add 1 to the amount of tiles needed
 @@next:
 lsr r0,r0,#3 //Get the amount of tiles needed
-cmp r0,r2 //If it's not the same amout as the characters, 
+cmp r0,r2 //If it's not the same amout as the characters... 
 beq @@end
 sub r0,r2,r0
 lsl r0,r0,#1


### PR DESCRIPTION
The game printed one extra tile if the name was >= 4 characters long because it worked by using the amount of characters and not the amount of pixels.
Because of that, the new 5-characters long names caused the game to print a tile from either the other characters' names or the checkerboard names.
However, the issue was already in the game and noticeable with 4 characters names.

The inner PSI window Poo issue was a pointer to the party names which was not updated like the others.