### PR TITLE
Fix headers for Stored Goods, Teleport and Call

### DIFF
--- a/src/c/vwf.c
+++ b/src/c/vwf.c
@@ -206,10 +206,10 @@ int print_window_header_string(int *dest, byte *str, int x, int y)
     return pixelX - (x & 7);
 }
 
-void clear_window_header(int *dest)
+void clear_window_header(int *dest, int length, int x, int y)
 {
-    dest += (WINDOW_HEADER_X + (WINDOW_HEADER_Y * 32)) * 8;
-    clear_rect_ram(dest, 16, WINDOW_HEADER_BG);
+    dest += (x + (y * 32)) * 8;
+    clear_rect_ram(dest, length, WINDOW_HEADER_BG);
 }
 
 unsigned short* print_equip_header(int type, unsigned short *tilemap, unsigned int *dest, WINDOW *window)

--- a/src/c/vwf.h
+++ b/src/c/vwf.h
@@ -38,7 +38,7 @@ byte print_character_with_callback(byte chr, int x, int y, int font, int foregro
     int *dest, int (*getTileCallback)(int, int), int useTilemap);
 byte print_character_to_ram(byte chr, int *dest, int xOffset, int font, int foreground);
 int print_window_header_string(int *dest, byte *str, int x, int y);
-void clear_window_header(int *dest);
+void clear_window_header(int *dest, int length, int x, int y);
 unsigned short* print_equip_header(int type, unsigned short *tilemap, unsigned int *dest,
     WINDOW *window);
 unsigned short format_tile(unsigned short tile, bool flip_x, bool flip_y);

--- a/src/m2-hack.asm
+++ b/src/m2-hack.asm
@@ -116,6 +116,9 @@ b       0x80BADD8
 .org    0x80C55F8
 mov     r4,r0
 mov     r0,r9
+mov     r1,#0x10 //Tiles to clear
+mov     r2,#0x10 //x
+mov     r3,#0x11 //y
 bl      clear_window_header
 mov     r0,r4
 mov     r1,r6 // tilemap
@@ -793,6 +796,26 @@ nop
 // Carpainter's timing fix
 //---------------------------------------------------------
 .org 0x802A75F :: db 0x30 //Add 8 extra frames before the game can start reading again.
+
+//---------------------------------------------------------
+// Teleport header fix
+//---------------------------------------------------------
+.org 0x80C5DE0 :: bl c65da_clean_print //To:
+.org 0x80C5E30 :: bl c6190_clean_print //Number on first entering the menu
+.org 0x80C6190 :: bl c6190_clean_print //Number on page change
+.org 0x80C5E04 :: nop :: strh r0,[r4,#0] :: add r4,#2 :: nop ::nop //Remove extra tile
+
+//---------------------------------------------------------
+// Stored Goods header fix
+//---------------------------------------------------------
+.org 0x80C656C :: mov r2,#0x10 :: mov r3,#0x11 :: bl c6570_clean_print_change_pos :: b 0x80C65C0 //Changes position and cleans tiles for Stored Goods
+.org 0x80C65DA :: bl c65da_clean_print //Number on first entering the menu
+.org 0x80C6996 :: bl c65da_clean_print //Number on page change
+
+//---------------------------------------------------------
+// Call header fix
+//---------------------------------------------------------
+.org 0x80BD26A :: bl c6190_clean_print //Call:
 
 //---------------------------------------------------------
 // Fix windows printing too many tiles due to not going off of pixels, but off of characters

--- a/src/m2-vwf-entries.asm
+++ b/src/m2-vwf-entries.asm
@@ -1276,178 +1276,242 @@ pop     {pc}
 //==============================================================================
 //Hacks that load specific numbers for the new names
 _2352_load_1d7:
-mov r0,#0xEB
-lsl r0,r0,#1
-add r0,r0,#1
-bx lr
+mov     r0,#0xEB
+lsl     r0,r0,#1
+add     r0,r0,#1
+bx      lr
 
 _2372_load_1e5:
-mov r0,#0xF2
-lsl r0,r0,#1
-add r0,r0,#1
-bx lr
+mov     r0,#0xF2
+lsl     r0,r0,#1
+add     r0,r0,#1
+bx      lr
 
 c98c4_load_1d7:
-mov r4,#0xEB
-lsl r4,r4,#1
-add r4,r4,#1
-bx lr
+mov     r4,#0xEB
+lsl     r4,r4,#1
+add     r4,r4,#1
+bx      lr
 
 c98d4_load_1e5:
-mov r4,#0xF2
-lsl r4,r4,#1
-add r4,r4,#1
-bx lr
+mov     r4,#0xF2
+lsl     r4,r4,#1
+add     r4,r4,#1
+bx      lr
 
 //==============================================================================
 //Fast routine that uses the defaults and stores them. Original one is a nightmare. Rewriting it from scratch. r1 has the target address. r5 has 0.
 cb2f2_hardcoded_defaults:
-push {lr}
-mov r0,#0x7E //Ness' name
-strb r0,[r1,#0]
-mov r2,#0x95
-strb r2,[r1,#1]
-strb r2,[r1,#0xF]
-mov r0,#0xA3
-strb r0,[r1,#2]
-strb r0,[r1,#3]
-mov r4,#0xFF
-lsl r5,r4,#8
-strh r5,[r1,#4]
-add r1,#7
-mov r0,#0x80 //Paula's name
-strb r0,[r1,#0]
-strb r0,[r1,#0xE]
-mov r3,#0x91
-strb r3,[r1,#1]
-strb r3,[r1,#4]
-mov r0,#0xA5
-strb r0,[r1,#2]
-mov r0,#0x9C
-strb r0,[r1,#3]
-strb r5,[r1,#5]
-strb r4,[r1,#6]
-add r1,#7
-mov r0,#0x7A //Jeff's name
-strb r0,[r1,#0]
-mov r0,#0x95
-strb r0,[r1,#1]
-mov r0,#0x96
-strb r0,[r1,#2]
-strb r0,[r1,#3]
-strh r5,[r1,#4]
-add r1,#7
-strb r4,[r1,#4]
-mov r4,#0x9F //Poo's name
-strb r4,[r1,#1]
-strb r4,[r1,#2]
-strb r5,[r1,#3]
-add r1,#7
-mov r0,#0x7B //King's name
-strb r0,[r1,#0]
-mov r0,#0x99
-strb r0,[r1,#1]
-mov r0,#0x9E
-strb r0,[r1,#2]
-mov r0,#0x97
-strb r0,[r1,#3]
-strh r5,[r1,#4]
-add r1,#8
-mov r0,#0x83 //Steak's name
-strb r0,[r1,#0]
-mov r0,#0xA4
-strb r0,[r1,#1]
-strb r2,[r1,#2]
-strb r3,[r1,#3]
-mov r3,#0x9B
-strb r3,[r1,#4]
-mov r2,#0xFF
-strb r5,[r1,#5]
-strb r2,[r1,#6]
-add r1,#8
-mov r0,#0x82 //Rockin's name
-strb r0,[r1,#0]
-strb r4,[r1,#1]
-mov r0,#0x93
-strb r0,[r1,#2]
-strb r3,[r1,#3]
-mov r0,#0x99
-strb r0,[r1,#4]
-mov r0,#0x9E
-strb r0,[r1,#5]
-strh r5,[r1,#6]
-mov r2,#1
-mov r5,#0
+push    {lr}
+mov     r0,#0x7E //Ness' name
+strb    r0,[r1,#0]
+mov     r2,#0x95
+strb    r2,[r1,#1]
+strb    r2,[r1,#0xF]
+mov     r0,#0xA3
+strb    r0,[r1,#2]
+strb    r0,[r1,#3]
+mov     r4,#0xFF
+lsl     r5,r4,#8
+strh    r5,[r1,#4]
+add     r1,#7
+mov     r0,#0x80 //Paula's name
+strb    r0,[r1,#0]
+strb    r0,[r1,#0xE]
+mov     r3,#0x91
+strb    r3,[r1,#1]
+strb    r3,[r1,#4]
+mov     r0,#0xA5
+strb    r0,[r1,#2]
+mov     r0,#0x9C
+strb    r0,[r1,#3]
+strb    r5,[r1,#5]
+strb    r4,[r1,#6]
+add     r1,#7
+mov     r0,#0x7A //Jeff's name
+strb    r0,[r1,#0]
+mov     r0,#0x95
+strb    r0,[r1,#1]
+mov     r0,#0x96
+strb    r0,[r1,#2]
+strb    r0,[r1,#3]
+strh    r5,[r1,#4]
+add     r1,#7
+strb    r4,[r1,#4]
+mov     r4,#0x9F //Poo's name
+strb    r4,[r1,#1]
+strb    r4,[r1,#2]
+strb    r5,[r1,#3]
+add     r1,#7
+mov     r0,#0x7B //King's name
+strb    r0,[r1,#0]
+mov     r0,#0x99
+strb    r0,[r1,#1]
+mov     r0,#0x9E
+strb    r0,[r1,#2]
+mov     r0,#0x97
+strb    r0,[r1,#3]
+strh    r5,[r1,#4]
+add     r1,#8
+mov     r0,#0x83 //Steak's name
+strb    r0,[r1,#0]
+mov     r0,#0xA4
+strb    r0,[r1,#1]
+strb    r2,[r1,#2]
+strb    r3,[r1,#3]
+mov     r3,#0x9B
+strb    r3,[r1,#4]
+mov     r2,#0xFF
+strb    r5,[r1,#5]
+strb    r2,[r1,#6]
+add     r1,#8
+mov     r0,#0x82 //Rockin's name
+strb    r0,[r1,#0]
+strb    r4,[r1,#1]
+mov     r0,#0x93
+strb    r0,[r1,#2]
+strb    r3,[r1,#3]
+mov     r0,#0x99
+strb    r0,[r1,#4]
+mov     r0,#0x9E
+strb    r0,[r1,#5]
+strh    r5,[r1,#6]
+mov     r2,#1
+mov     r5,#0
 
-pop {pc}
+pop     {pc}
 
 //==============================================================================
 //Routine for window headers that fixes the issue character - tiles
 fix_char_tiles:
-push {lr}
-lsl r0,r2,#1
-lsl r1,r2,#2
-add r1,r1,r0 //Multiply r2 (character count) by 6
-lsr r0,r1,#3 //Divide by 8
-lsl r0,r0,#3 //Re-multiply by 8
-cmp r0,r1 //Can it stay in r0 pixels? (Was this a division by 8 without remainder?)
-beq @@next
-add r0,#8 //If it cannot stay in x tiles, add 1 to the amount of tiles needed
+push    {lr}
+lsl     r0,r2,#1
+lsl     r1,r2,#2
+add     r1,r1,r0 //Multiply r2 (character count) by 6
+lsr     r0,r1,#3 //Divide by 8
+lsl     r0,r0,#3 //Re-multiply by 8
+cmp     r0,r1 //Can it stay in r0 pixels? (Was this a division by 8 without remainder?)
+beq     @@next
+add     r0,#8 //If it cannot stay in x tiles, add 1 to the amount of tiles needed
+
 @@next:
-lsr r0,r0,#3 //Get the amount of tiles needed
-cmp r0,r2 //If it's not the same amout as the characters... 
-beq @@end
-sub r0,r2,r0
-lsl r0,r0,#1
-sub r6,r6,r0 //Remove the amount of extra tiles
+lsr     r0,r0,#3 //Get the amount of tiles needed
+cmp     r0,r2 //If it's not the same amout as the characters... 
+beq     @@end
+sub     r0,r2,r0
+lsl     r0,r0,#1
+sub     r6,r6,r0 //Remove the amount of extra tiles
+
 @@end:
-pop {pc}
+pop     {pc}
 
 //==============================================================================
 //Specific fix_char_tiles routine - Status window
 c0b28_fix_char_tiles:
-push {lr}
-bl fix_char_tiles
-ldr r0,[r4,#0] //Clobbered code
-add r0,#0xB3
-pop {pc}
+push    {lr}
+bl      fix_char_tiles
+ldr     r0,[r4,#0] //Clobbered code
+add     r0,#0xB3
+pop     {pc}
 
 //==============================================================================
 //Specific fix_char_tiles routine - Give window
 c009e_fix_char_tiles:
-push {lr}
-mov r2,r5
-bl fix_char_tiles
-ldr r2,=#0x30051EC //Clobbered code
-ldrh r0,[r2]
-pop {pc}
+push    {lr}
+mov     r2,r5
+bl      fix_char_tiles
+ldr     r2,=#0x30051EC //Clobbered code
+ldrh    r0,[r2]
+pop     {pc}
 
 //==============================================================================
 //Specific fix_char_tiles routine - Equip window
 c4bd6_fix_char_tiles:
-push {lr}
-mov r6,r7
-bl fix_char_tiles
-mov r7,r6
-ldr r2,=#0x30051EC //Clobbered code
-ldrh r0,[r2]
-pop {pc}
+push    {lr}
+mov     r6,r7
+bl      fix_char_tiles
+mov     r7,r6
+ldr     r2,=#0x30051EC //Clobbered code
+ldrh    r0,[r2]
+pop     {pc}
 
 .pool
 //==============================================================================
 //Specific fix_char_tiles routine - Outer PSI window
 c42e0_fix_char_tiles:
-push {lr}
-bl fix_char_tiles
-mov r2,r9 //Clobbered code
-ldrh r0,[r2,#0]
-pop {pc}
+push    {lr}
+bl      fix_char_tiles
+mov     r2,r9 //Clobbered code
+ldrh    r0,[r2,#0]
+pop     {pc}
 
 //==============================================================================
 //Specific fix_char_tiles routine - Inner PSI window - part 2
 c4448_fix_char_tiles:
-push {lr}
-bl fix_char_tiles
-mov r2,r8 //Clobbered code
-ldrh r0,[r2,#0]
-pop {pc}
+push    {lr}
+bl      fix_char_tiles
+mov     r2,r8 //Clobbered code
+ldrh    r0,[r2,#0]
+pop     {pc}
+
+//==============================================================================
+//Routine which clears the header and THEN makes it so the string is printed
+c6190_clean_print:
+push    {lr}
+push    {r0-r3}
+mov     r1,#6 //Number of tiles to clean
+bl      clear_window_header
+pop     {r0-r3}
+bl      0x80CAB90
+pop     {pc}
+
+//==============================================================================
+//Routine which clears the header and THEN makes it so the string is printed
+c65da_clean_print:
+push    {lr}
+push    {r0-r3}
+mov     r1,#3 //Number of tiles to clean
+bl      clear_window_header
+pop     {r0-r3}
+bl      0x80CAB90
+pop     {pc}
+
+//==============================================================================
+//Routine which clears the header and THEN makes it so the string is printed
+_0x10_clean_print:
+push    {lr}
+push    {r0-r3}
+mov     r1,#0x10 //Number of tiles to clean
+bl      clear_window_header
+pop     {r0-r3}
+bl      0x80CAB90
+pop     {pc}
+
+//==============================================================================
+//Routine which calls the header clearer and changes the position of Stored Goods in the arrangement
+c6570_clean_print_change_pos:
+push    {lr}
+bl      _0x10_clean_print
+ldr     r2,=#0x230 //Change starting position
+mov     r0,r2 //Clobbered code
+ldrh    r3,[r4,#0]
+add     r0,r0,r3
+mov     r2,r8
+ldrh    r1,[r2,#0]
+orr     r0,r1
+mov     r2,#0
+
+@@cycle: //Print 9 tiles in the arrangement
+lsl     r0,r0,#0x10
+lsr     r0,r0,#0x10
+mov     r1,r0
+add     r0,r1,#1
+strh    r1,[r5,#0]
+add     r5,#2
+add     r2,#1
+cmp     r2,#9
+bne     @@cycle
+
+pop     {pc}
+
+.pool

--- a/working/m12-other.json
+++ b/working/m12-other.json
@@ -126,7 +126,7 @@
       810724
     ],
     "Old": "ばしょ[00 FF]",
-    "New": "To[00 FF]"
+    "New": "To:[00 FF]"
   },
   {
     "OldPointer": 11647572,
@@ -134,7 +134,7 @@
       813508
     ],
     "Old": "➨あずかりもの(1)へ[00 FF]",
-    "New": "➨Stored goods(1)[00 FF]"
+    "New": "➨Stored Goods(1)[00 FF]"
   },
   {
     "OldPointer": 11647585,
@@ -143,13 +143,13 @@
       813768
     ],
     "Old": "➨あずかりもの(2)へ[00 FF]",
-    "New": "➨Stored goods(2)[00 FF]"
+    "New": "➨Stored Goods(2)[00 FF]"
   },
   {
     "OldPointer": 11647598,
     "PointerLocations": [],
     "Old": "➨あずかりもの(3)へ[00 FF]",
-    "New": "➨Stored goods(3)[00 FF]"
+    "New": "➨Stored Goods(3)[00 FF]"
   },
   {
     "OldPointer": 11647611,
@@ -157,6 +157,6 @@
       812788
     ],
     "Old": "あずかりもの[00 FF]",
-    "New": "Stored goods[00 FF]"
+    "New": "Stored Goods[00 FF]"
   }
 ]


### PR DESCRIPTION
Issue 28's first part (Stored g only) was that there was not enough space where Stored Goods was previously at. 
Moved it to the space which Weapons, Body, etc use, which is larger.

Issue 28's second part ("Call:" being on top of the text) was the same as issue 46 (which happened for Stored Goods' number too): window headers were not cleaned before writing, so you'd see text overlapping.
Added window header cleaning before printing for "To:", Teleport's number, "Stored Goods", Stored Goods' number and "Call:".

Also improved indentation of previous commits. In m2-vwf-entries.asm the real commit (the part not about the indentation) starts at line 1457.