### PR TITLE
Fix crash when Onett transitions to day

### DIFF
--- a/src/c/ext.c
+++ b/src/c/ext.c
@@ -25,3 +25,4 @@ void __attribute__((naked)) m2_setupbattlename(short value) {}
 void __attribute__((naked)) store_pixels_overworld() {}
 void __attribute__((naked)) m12_dim_palette(short* palette, int total, int dimmingFactor) {}
 int __attribute__((naked)) m2_jump_to_offset(byte* character) {}
+byte* __attribute__((naked)) m2_malloc(int size) {}

--- a/src/c/vwf.c
+++ b/src/c/vwf.c
@@ -2037,6 +2037,19 @@ int print_alphabet_buffer(WINDOW* window)
     }
 }
 
+int check_overworld_buffer()
+{
+    int address = *((int*)(OVERWORLD_BUFFER_POINTER));
+    if(address == 0)
+    {
+        int tmp_counter = m2_buffer_counter;
+        address = (int)m2_malloc(OVERWORLD_BUFFER_SIZE);
+        *((int*)(OVERWORLD_BUFFER_POINTER)) = address;
+        m2_buffer_counter = tmp_counter;
+    }
+    return address;
+}
+
 void load_pixels_overworld_buffer()
 {
     int tile = *tile_offset;

--- a/src/c/vwf.h
+++ b/src/c/vwf.h
@@ -23,7 +23,9 @@
 #define WINDOW_HEADER_Y 0x11
 #define WINDOW_HEADER_TILE (WINDOW_HEADER_X + (WINDOW_HEADER_Y * 32))
 
-#define OVERWORLD_BUFFER 0x2028008
+#define OVERWORLD_BUFFER_POINTER 0x2028008
+#define OVERWORLD_BUFFER_SIZE 0xA80
+#define OVERWORLD_BUFFER check_overworld_buffer()
 
 #define CUSTOMCC_SET_X 0x5F
 #define CUSTOMCC_ADD_X 0x60
@@ -126,6 +128,7 @@ int highlight_string(WINDOW* window, byte* str, unsigned short x, unsigned short
 void highlight_talk_to();
 unsigned short printstr_hlight_buffer(WINDOW* window, byte* str, unsigned short x, unsigned short y, bool highlight);
 unsigned short printstr_hlight_pixels_buffer(WINDOW* window, byte* str, unsigned short x, unsigned short y, bool highlight);
+int check_overworld_buffer();
 void load_pixels_overworld_buffer();
 void store_pixels_overworld_buffer(int totalYs);
 void store_pixels_overworld_buffer_totalTiles(int totalTiles);
@@ -134,6 +137,7 @@ void eb_cartridge_palette_change(bool background);
 extern unsigned short m2_coord_table_fast_progression[];
 extern unsigned short m2_coord_table[];
 extern byte m2_ness_name[];
+extern int m2_buffer_counter;
 extern int m2_bits_to_nybbles[];
 extern int m2_bits_to_nybbles_fast[];
 extern byte m2_nybbles_to_bits[];
@@ -175,3 +179,4 @@ extern void m2_sub_d6844();
 extern int m2_setupwindow(WINDOW* window, short window_x, short window_y, short window_width, short window_height);
 extern void m2_setupbattlename(short value);
 extern void store_pixels_overworld();
+extern byte* m2_malloc();

--- a/src/m2-hack.asm
+++ b/src/m2-hack.asm
@@ -55,7 +55,7 @@ mov     r3,6
 // Allocate the printing buffer when the content previously allocated is reset
 //---------------------------------------------------------
 
-.org 0x8005B80 :: bl _05b80_alloc_buffer
+.org 0x8005B80 :: bl _05b80_alloc_buffer_pointer
 
 //---------------------------------------------------------
 // C0A5C hacks (status window)
@@ -2059,9 +2059,7 @@ disclaimer_map:
 // Existing subroutines/data
 //==============================================================================
 
-.definelabel buffer_size            ,0x0000A80
 .definelabel buffer_subtractor      ,0x0000800
-.definelabel overworld_buffer       ,0x2028008
 .definelabel m2_hall_line_size      ,0x3000374
 .definelabel m2_ness_data           ,0x3001D54
 .definelabel m2_ness_name           ,0x3001F10
@@ -2080,6 +2078,7 @@ disclaimer_map:
 .definelabel m2_old_japanese_name   ,0x3001F42
 .definelabel m2_cstm_last_printed   ,0x3001F4F
 .definelabel m2_player1             ,0x3001F50
+.definelabel m2_buffer_counter      ,0x3002A4C
 .definelabel m2_script_readability  ,0x3004F08
 .definelabel m2_psi_exist           ,0x300525C
 .definelabel m2_active_window_pc    ,0x3005264
@@ -2092,6 +2091,7 @@ disclaimer_map:
 .definelabel m2_change_naming_space ,0x8004E08
 .definelabel m2_copy_name_temp_mem  ,0x8004E34
 .definelabel m2_insert_default_name ,0x8005708
+.definelabel m2_malloc              ,0x8005B9C
 .definelabel m2_get_hall_address    ,0x800D7BC
 .definelabel m12_dim_palette        ,0x80137DC
 .definelabel m2_enable_script       ,0x80A1F6C

--- a/src/m2-vwf-entries.asm
+++ b/src/m2-vwf-entries.asm
@@ -2618,12 +2618,12 @@ ldrb    r1,[r4,#0x3] //If it is, sets vwf_skip to true, clears the window and up
 mov     r2,#1
 orr     r2,r1
 strb    r2,[r4,#0x3]
-mov     r3,r0
+push    {r0}
 bl      check_overworld_buffer
 ldr     r1,=#buffer_subtractor
 sub     r1,r0,r1
 mov     r0,r4
-mov     r4,r3
+pop     {r4}
 bl      clear_window_buffer
 mov     r0,r4
 bl      psiTargetWindow_buffer

--- a/src/m2-vwf-entries.asm
+++ b/src/m2-vwf-entries.asm
@@ -490,8 +490,10 @@ cmp     r0,0
 beq     @@next
 
 // If flag 0x10 is set, clear the PSI window
+bl      check_overworld_buffer
+ldr     r1,=#buffer_subtractor
+sub     r1,r0,r1
 ldr     r0,[r5,0x1C] // PSI window
-ldr     r1,=#overworld_buffer - buffer_subtractor
 bl      clear_window_buffer
 
 @@next:
@@ -748,8 +750,10 @@ ldr     r0,=0x3002500
 ldrh    r0,[r0]
 cmp     r0,0
 beq     @@next
+bl      check_overworld_buffer
+ldr     r1,=#buffer_subtractor
+sub     r1,r0,r1
 ldr     r0,=#0x3005230
-ldr     r1,=#overworld_buffer - buffer_subtractor
 ldr     r0,[r0,0x1C]
 bl      clear_window_buffer
 
@@ -2615,8 +2619,10 @@ mov     r2,#1
 orr     r2,r1
 strb    r2,[r4,#0x3]
 mov     r3,r0
+bl      check_overworld_buffer
+ldr     r1,=#buffer_subtractor
+sub     r1,r0,r1
 mov     r0,r4
-ldr     r1,=#overworld_buffer - buffer_subtractor
 mov     r4,r3
 bl      clear_window_buffer
 mov     r0,r4
@@ -2906,7 +2912,11 @@ pop     {r4,pc}
 //Prints blankstr in the buffer
 bb21c_print_blankstr_buffer:
 push    {lr}
-ldr     r3,=#overworld_buffer - buffer_subtractor
+push    {r0-r2}
+bl      check_overworld_buffer
+ldr     r3,=#buffer_subtractor
+sub     r3,r0,r3
+pop     {r0-r2}
 bl      print_blankstr_buffer
 pop     {pc}
 
@@ -2914,7 +2924,11 @@ pop     {pc}
 //Prints blankstr in the buffer and stores it
 bb21c_print_blankstr_buffer_store:
 push    {lr}
-ldr     r3,=#overworld_buffer - buffer_subtractor
+push    {r0-r2}
+bl      check_overworld_buffer
+ldr     r3,=#buffer_subtractor
+sub     r3,r0,r3
+pop     {r0-r2}
 bl      print_blankstr_buffer
 bl      store_pixels_overworld
 pop     {pc}
@@ -3303,11 +3317,11 @@ bl      store_pixels_overworld
 pop     {pc}
 
 //==============================================================================
-//Allocs the printing buffer. The buffer currently is 0xA80 bytes long
-_05b80_alloc_buffer:
+//Allocs the printing buffer's pointer. It needs 4 bytes
+_05b80_alloc_buffer_pointer:
 push    {lr}
 
-ldr     r0,=#buffer_size
+mov     r0,#4
 bl      0x8005B9C
 
 ldr     r0,=#0x3002A4C


### PR DESCRIPTION
It was caused by the printing buffer being always loaded.
Now the game only loads the buffer when it needs it.