### PR TITLE
Fix https://github.com/jeffman/Mother2GbaTranslation/issues/134

### DIFF
--- a/src/m2-hack.asm
+++ b/src/m2-hack.asm
@@ -780,6 +780,10 @@ b       0x80D3178
 // D31F8 hacks (print money balance)
 //---------------------------------------------------------
 
+// Saturn weld entry
+.org    0x80D3256
+bl      weld_entry_saturn
+
 .org 0x80D327E
 ldrb    r0,[r7]
 bl      decode_character


### PR DESCRIPTION
Adds a way to print saturn text for the 1A FF 04 00 control code.