### PR TITLE
Improve Test PR security

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -2,6 +2,8 @@ name: Test PR
 on:
   pull_request_target:
     branches: master
+    
+permissions: read-all
 
 jobs:
   test:


### PR DESCRIPTION
Making it so the github token can only read by default should help secure this...